### PR TITLE
Some refactoring of the resource classes.

### DIFF
--- a/skew/resources/aws/__init__.py
+++ b/skew/resources/aws/__init__.py
@@ -10,3 +10,173 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
+import logging
+import datetime
+
+import jmespath
+
+from skew.resources.resource import Resource
+from skew.arn.endpoint import Endpoint
+
+LOG = logging.getLogger(__name__)
+
+
+class MetricData(object):
+
+    def __init__(self, data, period):
+        self.data = data
+        self.period = period
+
+
+class AWSResource(Resource):
+    """
+    Each Resource class defines a Config variable at the class level.  This
+    is a dictionary that gives the specifics about which service the resource
+    belongs to and how to enumerate the resource.
+
+    Each entry in the dictionary we define:
+
+    * service - The AWS service in which this resource is defined.
+    * enum_spec - The enumeration configuration.  This is a tuple consisting
+      of the name of the operation to call to enumerate the resources and
+      a jmespath query that will be run against the result of the operation
+      to retrieve the list of resources.
+    * detail_spec - Some services provide only summary information in the
+      list or describe method and require you to make another request to get
+      the detailed info for a specific resource.  If that is the case, this
+      would contain a tuple consisting of the operation to call for the
+      details, the parameter name to pass in to identify the desired
+      resource and the jmespath filter to apply to the results to get
+      the details.
+    * id - The name of the field within the resource data that uniquely
+      identifies the resource.
+    * dimension - The CloudWatch dimension for this resource.  A value
+      of None indicates that this resource is not monitored by CloudWatch.
+    * filter_name - By default, the enumerator returns all resources of a
+      given type.  But you can also tell it to filter the results by
+      passing in a list of id's.  This parameter tells it the name of the
+      parameter to use to specify this list of id's.
+    """
+
+    class Meta(object):
+        type = 'awsresource'
+
+    @classmethod
+    def filter(cls, resource_id, data):
+        pass
+
+    def __init__(self, endpoint, data):
+        self._endpoint = endpoint
+        self._region = endpoint.region
+        self._account = endpoint.account
+        if data is None:
+            data = {}
+        self.data = data
+        if hasattr(self.Meta, 'id') and isinstance(self.data, dict):
+            self._id = self.data.get(self.Meta.id, '')
+        else:
+            self._id = ''
+        self._cloudwatch = None
+        if hasattr(self.Meta, 'dimension'):
+            cloudwatch = self._endpoint.service.session.get_service(
+                'cloudwatch')
+            self._cloudwatch = Endpoint(
+                cloudwatch, self._region, self._account)
+        self._metrics = None
+        self._name = None
+        self._date = None
+
+    def __repr__(self):
+        return self.arn
+
+    @property
+    def arn(self):
+        return 'arn:aws:%s:%s:%s:%s/%s' % (
+            self._endpoint.service.endpoint_prefix,
+            self._region, self._account, self.resourcetype, self.id)
+
+    @property
+    def metrics(self):
+        if self._metrics is None:
+            if self._cloudwatch:
+                data = self._cloudwatch.call(
+                    'ListMetrics',
+                    dimensions=[{'Name': self.Meta.dimension,
+                                 'Value': self._id}])
+                self._metrics = jmespath.search('Metrics', data)
+            else:
+                self._metrics = []
+        return self._metrics
+
+    def find_metric(self, metric_name):
+        for m in self.metrics:
+            if m['MetricName'] == metric_name:
+                return m
+        return None
+
+    def _total_seconds(self, delta):
+        # python2.6 does not have timedelta.total_seconds() so we have
+        # to calculate this ourselves.  This is straight from the
+        # datetime docs.
+        return ((delta.microseconds + (delta.seconds + delta.days * 24 * 3600)
+                 * 10 ** 6) / 10 ** 6)
+
+    def get_metric_data(self, metric_name, days=None, hours=1, minutes=None,
+                        statistics=None, period=None):
+        """
+        Get metric data for this resource.  You can specify the time
+        frame for the data as either the number of days or number of
+        hours.  The maximum window is 14 days.  Based on the time frame
+        this method will calculate the correct ``period`` to return
+        the maximum number of data points up to the CloudWatch max
+        of 1440.
+
+        :type metric_name: str
+        :param metric_name: The name of the metric this data will
+            pertain to.
+
+        :type days: int
+        :param days: The number of days worth of data to return.
+            You can specify either ``days`` or ``hours``.  The default
+            is one hour.  The maximum value is 14 days.
+
+        :type hours: int
+        :param hours: The number of hours worth of data to return.
+            You can specify either ``days`` or ``hours``.  The default
+            is one hour.  The maximum value is 14 days.
+
+        :type statistics: list of str
+        :param statistics: The metric statistics to return.  The default
+            value is **Average**.  Possible values are:
+
+            * Average
+            * Sum
+            * SampleCount
+            * Maximum
+            * Minimum
+        """
+        if not statistics:
+            statistics = ['Average']
+        if days:
+            delta = datetime.timedelta(days=days)
+        elif hours:
+            delta = datetime.timedelta(hours=hours)
+        else:
+            delta = datetime.timedelta(minutes=minutes)
+        if not period:
+            period = max(60, self._total_seconds(delta) // 1440)
+        metric = self.find_metric(metric_name)
+        if metric and self._cloudwatch:
+            end = datetime.datetime.utcnow()
+            start = end - delta
+            data = self._cloudwatch.call(
+                'GetMetricStatistics',
+                dimensions=metric['Dimensions'],
+                namespace=metric['Namespace'],
+                metric_name=metric['MetricName'],
+                start_time=start.isoformat(), end_time=end.isoformat(),
+                statistics=statistics, period=period)
+            return MetricData(jmespath.search('Datapoints', data), period)
+        else:
+            raise ValueError('Metric (%s) not available' % metric_name)

--- a/skew/resources/aws/autoscaling.py
+++ b/skew/resources/aws/autoscaling.py
@@ -13,10 +13,10 @@
 
 import jmespath
 
-import skew.resources.resource
+from skew.resources.aws import AWSResource
 
 
-class AutoScalingGroup(skew.resources.resource.Resource):
+class AutoScalingGroup(AWSResource):
 
     class Meta(object):
         service = 'autoscaling'

--- a/skew/resources/aws/cloudwatch.py
+++ b/skew/resources/aws/cloudwatch.py
@@ -1,8 +1,20 @@
+# Copyright (c) 2014 Mitch Garnaat http://garnaat.org/
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 
-import skew.resources.resource
+from skew.resources.aws import AWSResource
 
 
-class Alarm(skew.resources.resource.Resource):
+class Alarm(AWSResource):
 
     class Meta(object):
         service = 'cloudwatch'

--- a/skew/resources/aws/dynamodb.py
+++ b/skew/resources/aws/dynamodb.py
@@ -11,12 +11,17 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import logging
+
 import jmespath
 
-import skew.resources.resource
+from skew.resources.aws import AWSResource
 
 
-class Table(skew.resources.resource.Resource):
+LOG = logging.getLogger(__name__)
+
+
+class Table(AWSResource):
 
     class Meta(object):
         service = 'dynamodb'
@@ -28,6 +33,11 @@ class Table(skew.resources.resource.Resource):
         name = 'TableName'
         date = 'CreationDateTime'
         dimension = 'TableName'
+
+    @classmethod
+    def filter(cls, resource_id, data):
+        LOG.debug('%s == %s', resource_id, data)
+        return resource_id == data
 
     def __init__(self, endpoint, data):
         super(Table, self).__init__(endpoint, data)

--- a/skew/resources/aws/ec2.py
+++ b/skew/resources/aws/ec2.py
@@ -11,10 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import skew.resources.resource
+from skew.resources.aws import AWSResource
 
 
-class Instance(skew.resources.resource.Resource):
+class Instance(AWSResource):
 
     class Meta(object):
         service = 'ec2'
@@ -32,7 +32,7 @@ class Instance(skew.resources.resource.Resource):
         return self.data['ImageId']
 
 
-class SecurityGroup(skew.resources.resource.Resource):
+class SecurityGroup(AWSResource):
 
     class Meta(object):
         service = 'ec2'

--- a/skew/resources/aws/elb.py
+++ b/skew/resources/aws/elb.py
@@ -11,10 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import skew.resources.resource
+from skew.resources.aws import AWSResource
 
 
-class LoadBalancer(skew.resources.resource.Resource):
+class LoadBalancer(AWSResource):
 
     class Meta(object):
         service = 'elb'

--- a/skew/resources/aws/iam.py
+++ b/skew/resources/aws/iam.py
@@ -11,10 +11,15 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import skew.resources.resource
+import logging
+
+from skew.resources.aws import AWSResource
 
 
-class Group(skew.resources.resource.Resource):
+LOG = logging.getLogger(__name__)
+
+
+class Group(AWSResource):
 
     class Meta(object):
         service = 'iam'
@@ -27,8 +32,13 @@ class Group(skew.resources.resource.Resource):
         date = 'CreateDate'
         dimension = None
 
+    @classmethod
+    def filter(cls, resource_id, data):
+        LOG.debug('%s == %s', resource_id, data)
+        return resource_id == data['GroupName']
 
-class User(skew.resources.resource.Resource):
+
+class User(AWSResource):
 
     class Meta(object):
         service = 'iam'
@@ -40,3 +50,8 @@ class User(skew.resources.resource.Resource):
         name = 'UserName'
         date = 'CreateDate'
         dimension = None
+
+    @classmethod
+    def filter(cls, resource_id, data):
+        LOG.debug('%s == %s', resource_id, data)
+        return resource_id == data['UserName']

--- a/skew/resources/aws/rds.py
+++ b/skew/resources/aws/rds.py
@@ -11,10 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import skew.resources.resource
+from skew.resources.aws import AWSResource
 
 
-class DBInstance(skew.resources.resource.Resource):
+class DBInstance(AWSResource):
 
     class Meta(object):
         service = 'rds'
@@ -28,7 +28,7 @@ class DBInstance(skew.resources.resource.Resource):
         dimension = 'DBInstanceIdentifier'
 
 
-class DBSecurityGroup(skew.resources.resource.Resource):
+class DBSecurityGroup(AWSResource):
 
     class Meta(object):
         service = 'rds'

--- a/skew/resources/aws/route53.py
+++ b/skew/resources/aws/route53.py
@@ -11,10 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import skew.resources.resource
+from skew.resources.aws import AWSResource
 
 
-class HostedZone(skew.resources.resource.Resource):
+class HostedZone(AWSResource):
 
     class Meta(object):
         service = 'route53'

--- a/skew/resources/resource.py
+++ b/skew/resources/resource.py
@@ -12,51 +12,12 @@
 # language governing permissions and limitations under the License.
 
 import logging
-import datetime
-
 import jmespath
-
-from skew.arn.endpoint import Endpoint
 
 LOG = logging.getLogger(__name__)
 
 
-class MetricData(object):
-
-    def __init__(self, data, period):
-        self.data = data
-        self.period = period
-
-
 class Resource(object):
-    """
-    Each Resource class defines a Config variable at the class level.  This
-    is a dictionary that gives the specifics about which service the resource
-    belongs to and how to enumerate the resource.
-
-    Each entry in the dictionary we define:
-
-    * service - The AWS service in which this resource is defined.
-    * enum_spec - The enumeration configuration.  This is a tuple consisting
-      of the name of the operation to call to enumerate the resources and
-      a jmespath query that will be run against the result of the operation
-      to retrieve the list of resources.
-    * detail_spec - Some services provide only summary information in the
-      list or describe method and require you to make another request to get
-      the detailed info for a specific resource.  If that is the case, this
-      would contain a tuple consisting of the operation to call for the
-      details, the parameter name to pass in to identify the desired
-      resource and the jmespath filter to apply to the results to get
-      the details.
-    * id - The name of the field within the resource data that uniquely
-      identifies the resource.
-    * dimension - The CloudWatch dimension for this resource.  A value
-      of None indicates that this resource is not monitored by CloudWatch.
-    * filter_name - By default, the enumerator returns all resources of a
-      given type.  But you can also tell it to filter the results by
-      passing in a list of id's.  This parameter tells it the name of the
-      parameter to use to specify this list of id's.
-    """
 
     class Meta(object):
         type = 'resource'
@@ -72,13 +33,7 @@ class Resource(object):
             self._id = self.data.get(self.Meta.id, '')
         else:
             self._id = ''
-        self._cloudwatch = None
-        if hasattr(self.Meta, 'dimension'):
-            cloudwatch = self._endpoint.service.session.get_service(
-                'cloudwatch')
-            self._cloudwatch = Endpoint(
-                cloudwatch, self._region, self._account)
-        self._metrics = None
+        self._metrics = list()
         self._name = None
         self._date = None
 
@@ -118,14 +73,7 @@ class Resource(object):
     @property
     def metrics(self):
         if self._metrics is None:
-            if self._cloudwatch:
-                data = self._cloudwatch.call(
-                    'ListMetrics',
-                    dimensions=[{'Name': self.Meta.dimension,
-                                 'Value': self._id}])
-                self._metrics = jmespath.search('Metrics', data)
-            else:
-                self._metrics = []
+            self._metrics = []
         return self._metrics
 
     @property
@@ -137,13 +85,6 @@ class Resource(object):
             if m['MetricName'] == metric_name:
                 return m
         return None
-
-    def _total_seconds(self, delta):
-        # python2.6 does not have timedelta.total_seconds() so we have
-        # to calculate this ourselves.  This is straight from the
-        # datetime docs.
-        return ((delta.microseconds + (delta.seconds + delta.days * 24 * 3600)
-                 * 10 ** 6) / 10 ** 6)
 
     def get_metric_data(self, metric_name, days=None, hours=1, minutes=None,
                         statistics=None, period=None):
@@ -179,30 +120,7 @@ class Resource(object):
             * Maximum
             * Minimum
         """
-        if not statistics:
-            statistics = ['Average']
-        if days:
-            delta = datetime.timedelta(days=days)
-        elif hours:
-            delta = datetime.timedelta(hours=hours)
-        else:
-            delta = datetime.timedelta(minutes=minutes)
-        if not period:
-            period = max(60, self._total_seconds(delta) // 1440)
-        metric = self.find_metric(metric_name)
-        if metric and self._cloudwatch:
-            end = datetime.datetime.utcnow()
-            start = end - delta
-            data = self._cloudwatch.call(
-                'GetMetricStatistics',
-                dimensions=metric['Dimensions'],
-                namespace=metric['Namespace'],
-                metric_name=metric['MetricName'],
-                start_time=start.isoformat(), end_time=end.isoformat(),
-                statistics=statistics, period=period)
-            return MetricData(jmespath.search('Datapoints', data), period)
-        else:
-            raise ValueError('Metric (%s) not available' % metric_name)
+        pass
 
     def summary(self, metric_name):
         return self.get_metric_data(

--- a/tests/unit/data/dynamodb_tables.json
+++ b/tests/unit/data/dynamodb_tables.json
@@ -1,1 +1,1 @@
-{"TableNames":["Foo","Bar"]}
+{"TableNames":["foo","bar"]}


### PR DESCRIPTION
  Also, fixed an issue involving filtering of results.  Some API's allow you to filter the results of Decribe\* operations to return a single resource and others (like DynamoDB and IAM) do not.  So for those services, even if you specified a resource_id (e.g. table/foobar) the ARN would return all of the tables.  This fixes that issue.
