### PR TITLE
Added a filter_type attribute 

### DIFF
--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -189,7 +189,10 @@ class ARNEnumerator(object):
                 # after we get all of the results.
                 filter_name = resource_cls.Meta.filter_name
                 if filter_name:
-                    kwargs[filter_name] = [resource_id]
+                    if resource_cls.Meta.filter_type == 'list':
+                        kwargs[filter_name] = [resource_id]
+                    else:
+                        kwargs[filter_name] = resource_id
                 else:
                     do_client_side_filtering = True
             enum_op, path = resource_cls.Meta.enum_spec

--- a/skew/resources/aws/__init__.py
+++ b/skew/resources/aws/__init__.py
@@ -137,7 +137,8 @@ class AWSResource(Resource):
         return ((delta.microseconds + (delta.seconds + delta.days * 24 * 3600)
                  * 10 ** 6) / 10 ** 6)
 
-    def get_metric_data(self, metric_name, days=None, hours=1, minutes=None,
+    def get_metric_data(self, metric_name=None, metric=None,
+                        days=None, hours=1, minutes=None,
                         statistics=None, period=None):
         """
         Get metric data for this resource.  You can specify the time
@@ -181,7 +182,8 @@ class AWSResource(Resource):
             delta = datetime.timedelta(minutes=minutes)
         if not period:
             period = max(60, self._total_seconds(delta) // 1440)
-        metric = self.find_metric(metric_name)
+        if not metric:
+            metric = self.find_metric(metric_name)
         if metric and self._cloudwatch:
             end = datetime.datetime.utcnow()
             start = end - delta

--- a/skew/resources/aws/autoscaling.py
+++ b/skew/resources/aws/autoscaling.py
@@ -28,6 +28,7 @@ class AutoScalingGroup(AWSResource):
         detail_spec = None
         id = 'AutoScalingGroupName'
         filter_name = 'auto_scaling_group_names'
+        filter_type = 'list'
 
     def __init__(self, endpoint, data):
         super(AutoScalingGroup, self).__init__(endpoint, data)
@@ -50,6 +51,7 @@ class LaunchConfiguration(AWSResource):
         detail_spec = None
         id = 'LaunchConfigurationName'
         filter_name = 'launch_configuration_names'
+        filter_type = 'list'
 
     def __init__(self, endpoint, data):
         super(LaunchConfiguration, self).__init__(endpoint, data)

--- a/skew/resources/aws/cloudwatch.py
+++ b/skew/resources/aws/cloudwatch.py
@@ -22,6 +22,7 @@ class Alarm(AWSResource):
         enum_spec = ('DescribeAlarms', 'MetricAlarms')
         id = 'AlarmArn'
         filter_name = 'alarm_names'
+        filter_type = 'list'
         detail_spec = None
         name = 'AlarmName'
         date = 'AlarmConfigurationUpdatedTimestamp'

--- a/skew/resources/aws/ec2.py
+++ b/skew/resources/aws/ec2.py
@@ -23,6 +23,7 @@ class Instance(AWSResource):
         detail_spec = None
         id = 'InstanceId'
         filter_name = 'instance_ids'
+        filter_type = 'list'
         name = 'PublicDnsName'
         date = 'LaunchTime'
         dimension = 'InstanceId'
@@ -41,6 +42,7 @@ class SecurityGroup(AWSResource):
         detail_spec = None
         id = 'GroupId'
         filter_name = 'group_names'
+        filter_type = 'list'
         name = 'GroupName'
         date = None
         dimension = None
@@ -69,6 +71,7 @@ class Address(AWSResource):
         detail_spec = None
         id = 'PublicIp'
         filter_name = 'public-ips'
+        filter_type = 'list'
         name = 'PublicIp'
         date = None
         dimension = None

--- a/skew/resources/aws/elb.py
+++ b/skew/resources/aws/elb.py
@@ -23,6 +23,7 @@ class LoadBalancer(AWSResource):
         detail_spec = None
         id = 'LoadBalancerName'
         filter_name = 'load_balancer_names'
+        filter_type = 'list'
         name = 'DNSName'
         date = 'CreatedTime'
         dimension = 'LoadBalancerName'

--- a/skew/resources/aws/rds.py
+++ b/skew/resources/aws/rds.py
@@ -23,6 +23,7 @@ class DBInstance(AWSResource):
         detail_spec = None
         id = 'DBInstanceIdentifier'
         filter_name = 'db_instance_identfier'
+        filter_type = 'scalar'
         name = 'Endpoint.Address'
         date = 'InstanceCreateTime'
         dimension = 'DBInstanceIdentifier'
@@ -37,6 +38,7 @@ class DBSecurityGroup(AWSResource):
         detail_spec = None
         id = 'DBSecurityGroupName'
         filter_name = 'db_security_group_name'
+        filter_type = 'scalar'
         name = 'DBSecurityGroupDescription'
         date = None
         dimension = None

--- a/skew/resources/aws/redshift.py
+++ b/skew/resources/aws/redshift.py
@@ -23,6 +23,7 @@ class Cluster(AWSResource):
         detail_spec = None
         id = 'ClusterIdentifier'
         filter_name = 'cluster_identifier'
+        filter_type = 'scalar'
         name = 'ClusterIdentifier'
         date = 'ClusterCreateTime'
         dimension = 'ClusterIdentifier'


### PR DESCRIPTION
Because some AWS API calls accept a list of filter IDs and some accept only a single value.
