### PR TITLE
workaround "AttributeError: 'str' object has no attribute 'get'" error

### DIFF
--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -159,6 +159,8 @@ class Account(ARNComponent):
         """
         account_map = {}
         for profile in session.available_profiles:
+            if profile == '_path':
+                continue
             session.profile = profile
             config = session.get_scoped_config()
             account_id = config.get('account_id')


### PR DESCRIPTION
I was trying to get your examples to run, but got AttributeError all the time. I guess it was because changes in botocore. I made it to work with this change. I am not sure if it's the correct fix for the problem, but it works for me this way.
