### PR TITLE
Changing the way botocore sessions are created.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six>=1.8.0,<2.0.0
-botocore==0.77.0
+botocore==0.81.0
 mock==1.0.1
 httpretty==0.8.3
 python-dateutil>=2.1,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 requires = [
     'six>=1.8.0,<2.0.0',
-    'botocore==0.77.0',
+    'botocore==0.81.0',
     'python-dateutil>=2.1,<3.0.0']
 
 

--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -23,15 +23,7 @@ import skew.resources
 from skew.arn.endpoint import Endpoint
 
 LOG = logging.getLogger(__name__)
-
-#
-# Define an event that gets fired when a new resource is created.
-#
-#     resource-create.aws.<service>.<region>.<account>.<resource_type>.<id>
-
-resource_events = {
-    'resource-create': '.%s.%s.%s.%s.%s.%s'
-}
+DebugFmtString = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 
 
 class ARNComponent(object):
@@ -102,7 +94,13 @@ class Resource(ARNComponent):
 
     def enumerate(self, values):
         _, provider, service_name, region, account = values
-        service = self._arn.session.get_service(service_name)
+        LOG.debug('enumerate, account=%s', account)
+        profile = self._arn.account.map_account_to_profile(account)
+        LOG.debug('enumerate, profile=%s', profile)
+        session = botocore.session.get_session()
+        session.profile = profile
+        LOG.debug('enumerate, access_key=%s', session.get_credentials().access_key)
+        service = session.get_service(service_name)
         endpoint = Endpoint(service, region, account)
         resource_type, resource_id = self._split_resource(self.pattern)
         LOG.debug('resource_type=%s, resource_id=%s',
@@ -138,25 +136,22 @@ class Resource(ARNComponent):
                     if not resource_cls.filter(resource_id, d):
                         continue
                 resource = resource_cls(endpoint, d, self._arn.query)
-                self._arn.fire_event(
-                    'resource-create', self._arn.provider,
-                    service_name, region, account,
-                    resource_type, resource.id, resource=resource)
                 yield resource
 
 
 class Account(ARNComponent):
 
     def __init__(self, pattern, arn):
-        self._account_map = self._build_account_map(arn.session)
+        self._account_map = self._build_account_map()
         super(Account, self).__init__(pattern, arn)
 
-    def _build_account_map(self, session):
+    def _build_account_map(self):
         """
         Builds up a dictionary mapping account IDs to profile names.
         Any profile which includes an ``account_name`` variable is
         included.
         """
+        session = botocore.session.get_session()
         account_map = {}
         for profile in session.available_profiles:
             session.profile = profile
@@ -168,6 +163,9 @@ class Account(ARNComponent):
 
     def _get_choices(self):
         return list(self._account_map.keys())
+
+    def map_account_to_profile(self, account):
+        return self._account_map[account]
 
     def enumerate(self, values):
         for match in self.matches:
@@ -216,7 +214,8 @@ class Region(ARNComponent):
 class Service(ARNComponent):
 
     def _get_choices(self):
-        return self._arn.session.get_available_services()
+        session = botocore.session.get_session()
+        return session.get_available_services()
 
     def enumerate(self, values):
         for match in self.matches:
@@ -255,19 +254,38 @@ class ARN(object):
     ComponentClasses = [Scheme, Provider, Service, Region, Account, Resource]
 
     def __init__(self, arn_string='arn:aws:*:*:*:*'):
-        self.session = botocore.session.get_session()
         self.query = None
         self._components = None
         self._build_components_from_string(arn_string)
-        for event_name in resource_events:
-            self.session.register_event(
-                event_name, resource_events[event_name])
 
     def __repr__(self):
         return ':'.join([str(c) for c in self._components])
 
-    def debug(self, logger_name='skew'):
-        self.session.set_debug_logger(logger_name)
+    def debug(self):
+        self.set_logger('skew', logging.DEBUG)
+
+    def set_logger(self, logger_name, level=logging.INFO):
+        """
+        Convenience function to quickly configure full debug output
+        to go to the console.
+        """
+        log = logging.getLogger(logger_name)
+        log.setLevel(level)
+
+        ch = logging.StreamHandler(None)
+        ch.setLevel(level)
+
+        # create formatter
+        if level == logging.INFO:
+            formatter = logging.Formatter(InfoFmtString)
+        else:
+            formatter = logging.Formatter(DebugFmtString)
+
+        # add formatter to ch
+        ch.setFormatter(formatter)
+
+        # add ch to logger
+        log.addHandler(ch)
 
     def _build_components_from_string(self, arn_string):
         if '|' in arn_string:
@@ -276,20 +294,6 @@ class ARN(object):
         pairs = zip_longest(
             self.ComponentClasses, arn_string.split(':', 6), fillvalue='*')
         self._components = [c(n, self) for c, n in pairs]
-
-    def register_for_event(self, event, cb):
-        self.session.register(event, cb)
-
-    def fire_event(self, event_name, *fmtargs, **kwargs):
-        """
-        Each time a resource is enumerated, we fire an event of the
-        form:
-
-        resource-create.aws.<service>.<region>.<account>.<resource_type>.<id>
-        """
-        event = self.session.create_event(event_name, *fmtargs)
-        LOG.debug('firing event: %s', event)
-        self.session.emit(event, **kwargs)
 
     @property
     def scheme(self):

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -74,14 +74,6 @@ class TestARN(unittest.TestCase):
         self.assertEqual(users[0].data['UserName'], 'bar')
         self.assertEqual(users[0].name, 'bar')
 
-    # This callback will be associated with an event that gets fired
-    # when new EC2 Instance resources are created.  It will store a
-    # bogus attribute on each object and then we will look for them
-    # in the test method to verify that its getting called.
-    def _my_callback(self, event_name, resource, **kwargs):
-        self.assertIn('123456789012', event_name)
-        resource.__foobar__ = 'fiebaz'
-
     @httpretty.activate
     def test_ec2_instance(self):
         # Set up the HTTP mocking
@@ -105,15 +97,9 @@ class TestARN(unittest.TestCase):
                                ])
         # Run the test
         arn = scan('arn:aws:ec2:us-east-1:123456789012:instance/*')
-        # Register our local event handler
-        arn.register_for_event('resource-create.aws.ec2.*.*.instance.*',
-                               self._my_callback)
         # Fetch all Instance resources
         instances = list(arn)
         self.assertEqual(len(instances), 2)
-        # Check to see if our callback got called
-        for i in instances:
-            self.assertEqual(getattr(i, '__foobar__'), 'fiebaz')
         # Fetch non-existant resource
         arn = scan('arn:aws:ec2:us-east-1:123456789012:instance/i-decafbad')
         instances = list(arn)


### PR DESCRIPTION
Because changing the profile on an existing session does not re-fetch credentials so you are always stuck with the same set of credentials.  In the process, I also removed the event-related code since that is kind of obscure and not currently used.

Fixes #43 