### PR TITLE
fix(Set IAM to regionless.)

### DIFF
--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -174,14 +174,6 @@ class Account(ARNComponent):
 
 
 class Region(ARNComponent):
-
-    _region_names_limited = ['us-east-1',
-                             'us-west-2',
-                             'eu-west-1',
-                             'ap-southeast-1',
-                             'ap-southeast-2',
-                             'ap-northeast-1']
-
     _all_region_names = ['us-east-1',
                          'us-west-1',
                          'us-west-2',
@@ -192,14 +184,21 @@ class Region(ARNComponent):
                          'ap-northeast-1',
                          'sa-east-1']
 
-    _universal_region_names = ['us-east-1']
+    _region_names_limited = ['us-east-1',
+                             'us-west-2',
+                             'eu-west-1',
+                             'ap-southeast-1',
+                             'ap-southeast-2',
+                             'ap-northeast-1']
+
+    _no_region_required = ['']
 
     _service_region_map = {
         'redshift': _region_names_limited,
         'glacier': _region_names_limited,
         'kinesis': _region_names_limited,
-        'iam': _universal_region_names,
-        'route53': _universal_region_names}
+        'iam': _no_region_required,
+        'route53': _no_region_required}
 
     def choices(self, context=None):
         if context:

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -93,10 +93,10 @@ class TestARN(unittest.TestCase):
         self.assertEqual(len(l), 4)
 
     def test_iam_users(self):
-        arn = scan('arn:aws:iam:us-east-1:234567890123:user/*')
+        arn = scan('arn:aws:iam:*:234567890123:user/*')
         l = list(arn)
         self.assertEqual(len(l), 3)
-        arn = scan('arn:aws:iam:us-east-1:234567890123:user/foo')
+        arn = scan('arn:aws:iam:*:234567890123:user/foo')
         l = list(arn)
         self.assertEqual(len(l), 1)
 


### PR DESCRIPTION
This fix causes the IAM lookups to be run without adding a
specific region to the ARN's being constructed. This is needed
for properly resolving IAM policies and roles. Prior to the fix
a wildcard IAM search would not return any policies or roles.