### PR TITLE
Work In Progress: Threadsafe credential handling

### DIFF
--- a/skew/__init__.py
+++ b/skew/__init__.py
@@ -18,7 +18,7 @@ from skew.arn import ARN
 __version__ = open(os.path.join(os.path.dirname(__file__), '_version')).read()
 
 
-def scan(sku):
+def scan(sku, aws_creds=None):
     """
     Scan (i.e. look up) a SKU.
 
@@ -37,4 +37,4 @@ def scan(sku):
     but since there is currently only one (ARN) let's not over-complicate
     things.
     """
-    return ARN(sku)
+    return ARN(sku, aws_creds=aws_creds)

--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -108,7 +108,7 @@ class Resource(ARNComponent):
             all_resources = ['*']
         return all_resources
 
-    def enumerate(self, context):
+    def enumerate(self, context, aws_creds=None):
         LOG.debug('Resource.enumerate %s', context)
         _, provider, service_name, region, account = context
         resource_type, resource_id = self._split_resource(self.pattern)
@@ -119,7 +119,7 @@ class Resource(ARNComponent):
             resource_path = '.'.join([provider, service_name, resource_type])
             resource_cls = skew.resources.find_resource_class(resource_path)
             resources.extend(resource_cls.enumerate(
-                self._arn, region, account, resource_id))
+                self._arn, region, account, resource_id, aws_creds=aws_creds))
         return resources
 
 
@@ -132,11 +132,12 @@ class Account(ARNComponent):
     def choices(self, context=None):
         return list(self._accounts.keys())
 
-    def enumerate(self, context):
+    def enumerate(self, context, aws_creds=None):
         LOG.debug('Account.enumerate %s', context)
         for match in self.matches(context):
             context.append(match)
-            for resource in self._arn.resource.enumerate(context):
+            for resource in self._arn.resource.enumerate(
+                    context, aws_creds=aws_creds):
                 yield resource
             context.pop()
 
@@ -176,11 +177,12 @@ class Region(ARNComponent):
         return self._service_region_map.get(
             service, self._all_region_names)
 
-    def enumerate(self, context):
+    def enumerate(self, context, aws_creds=None):
         LOG.debug('Region.enumerate %s', context)
         for match in self.matches(context):
             context.append(match)
-            for account in self._arn.account.enumerate(context):
+            for account in self._arn.account.enumerate(
+                    context, aws_creds=aws_creds):
                 yield account
             context.pop()
 
@@ -194,11 +196,12 @@ class Service(ARNComponent):
             provider = self._arn.provider.pattern
         return skew.resources.all_services(provider)
 
-    def enumerate(self, context):
+    def enumerate(self, context, aws_creds=None):
         LOG.debug('Service.enumerate %s', context)
         for match in self.matches(context):
             context.append(match)
-            for region in self._arn.region.enumerate(context):
+            for region in self._arn.region.enumerate(
+                    context, aws_creds=aws_creds):
                 yield region
             context.pop()
 
@@ -208,11 +211,12 @@ class Provider(ARNComponent):
     def choices(self, context=None):
         return ['aws']
 
-    def enumerate(self, context):
+    def enumerate(self, context, aws_creds=None):
         LOG.debug('Provider.enumerate %s', context)
         for match in self.matches(context):
             context.append(match)
-            for service in self._arn.service.enumerate(context):
+            for service in self._arn.service.enumerate(
+                    context, aws_creds=aws_creds):
                 yield service
             context.pop()
 
@@ -222,11 +226,12 @@ class Scheme(ARNComponent):
     def choices(self, context=None):
         return ['arn']
 
-    def enumerate(self, context):
+    def enumerate(self, context, aws_creds=None):
         LOG.debug('Scheme.enumerate %s', context)
         for match in self.matches(context):
             context.append(match)
-            for provider in self._arn.provider.enumerate(context):
+            for provider in self._arn.provider.enumerate(
+                    context, aws_creds=aws_creds):
                 yield provider
             context.pop()
 
@@ -235,10 +240,11 @@ class ARN(object):
 
     ComponentClasses = [Scheme, Provider, Service, Region, Account, Resource]
 
-    def __init__(self, arn_string='arn:aws:*:*:*:*'):
+    def __init__(self, arn_string='arn:aws:*:*:*:*', aws_creds=None):
         self.query = None
         self._components = None
         self._build_components_from_string(arn_string)
+        self.aws_creds = aws_creds
 
     def __repr__(self):
         return ':'.join([str(c) for c in self._components])
@@ -300,5 +306,5 @@ class ARN(object):
 
     def __iter__(self):
         context = []
-        for scheme in self.scheme.enumerate(context):
+        for scheme in self.scheme.enumerate(context, aws_creds=self.aws_creds):
             yield scheme

--- a/skew/awsclient.py
+++ b/skew/awsclient.py
@@ -24,14 +24,6 @@ from skew.config import get_config
 
 LOG = logging.getLogger(__name__)
 
-# Offer an override for setting credentials instead of falling back to the
-# ~/.aws/credentials file. Dict to be formatted as:
-# {'access_key': key, 'secret_key': secret, 'token': token}
-# Token is optional and only required for federated accounts.
-# In order for this to work, you must provide a
-# value to skew.config._config, i.e. {'accounts': {'123456789012': None}}
-global_aws_creds = {}
-
 
 def json_encoder(obj):
     """JSON encoder that formats datetimes as ISO8601 format."""
@@ -49,7 +41,7 @@ class AWSClient(object):
         self._region_name = region_name
         self._account_id = account_id
         self._has_credentials = False
-        if not (global_aws_creds or aws_creds):
+        if not aws_creds:
             # If no creds, need profile name to retrieve creds from ~/.aws/credentials
             self._profile = self._config['accounts'][account_id]['profile']
         self.aws_creds = aws_creds
@@ -113,9 +105,6 @@ class AWSClient(object):
         # Try using "local" creds first:
         if self.aws_creds:
             session.set_credentials(**self.aws_creds)
-        # Then try global:
-        elif global_aws_creds:
-            session.set_credentials(**global_aws_creds)
         else:
             session.set_config_variable('profile', self.profile)
         return session.create_client(

--- a/skew/resources/aws/s3.py
+++ b/skew/resources/aws/s3.py
@@ -24,9 +24,10 @@ class Bucket(AWSResource):
     _location_cache = {}
 
     @classmethod
-    def enumerate(cls, arn, region, account, resource_id=None):
+    def enumerate(cls, arn, region, account, resource_id=None, aws_creds=None):
         resources = super(Bucket, cls).enumerate(arn, region, account,
-                                                 resource_id)
+                                                 resource_id,
+                                                 aws_creds=aws_creds)
         client = skew.awsclient.get_awsclient(
             cls.Meta.service, region, account)
         region_resources = []

--- a/skew/resources/resource.py
+++ b/skew/resources/resource.py
@@ -23,9 +23,9 @@ LOG = logging.getLogger(__name__)
 class Resource(object):
 
     @classmethod
-    def enumerate(cls, arn, region, account, resource_id=None):
+    def enumerate(cls, arn, region, account, resource_id=None, aws_creds=None):
         client = skew.awsclient.get_awsclient(
-            cls.Meta.service, region, account)
+            cls.Meta.service, region, account, aws_creds=aws_creds)
         kwargs = {}
         do_client_side_filtering = False
         if resource_id and resource_id != '*':

--- a/tests/unit/mock_awsclient.py
+++ b/tests/unit/mock_awsclient.py
@@ -20,10 +20,11 @@ LOG = logging.getLogger(__name__)
 
 class MockAWSClient(object):
 
-    def __init__(self, service_name, region_name, account_id):
+    def __init__(self, service_name, region_name, account_id, aws_creds=None):
         self.service_name = service_name
         self.region_name = region_name
         self.account_id = account_id
+        self.aws_creds = aws_creds
 
     def _get_stored_response(self, op_name, kwargs):
         LOG.debug('op_name={}, kwargs={}'.format(op_name, kwargs))
@@ -51,5 +52,6 @@ class MockAWSClient(object):
         return self._get_stored_response(op_name, kwargs)
 
 
-def get_awsclient(service_name, region_name, account_id):
-    return MockAWSClient(service_name, region_name, account_id)
+def get_awsclient(service_name, region_name, account_id, aws_creds=None):
+    return MockAWSClient(service_name, region_name, account_id,
+                         aws_creds=aws_creds)


### PR DESCRIPTION
The global credential cache introduced in a [recent patch](https://github.com/josh-paul/skew/commit/ea86cdf4a0e3e492fe91d168f9934021ceba75cc) has proven to be problematic in a multi-threaded environment. We've seen cached credentials get leaked across thread boundaries, resulting in spurious errors.

This patch is an attempt to explicitly pass credentials programmatically but avoid using a global var for storing the credentials. I haven't spent much time on this so far, and wanted to get some feedback before I invest more time in it. Let me know what you think.