### PR TITLE
Splitting once too many times in ARN parsing code

### DIFF
--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -279,7 +279,7 @@ class ARN(object):
             arn_string, query = arn_string.split('|')
             self.query = jmespath.compile(query)
         pairs = zip_longest(
-            self.ComponentClasses, arn_string.split(':', 6), fillvalue='*')
+            self.ComponentClasses, arn_string.split(':', 5), fillvalue='*')
         self._components = [c(n, self) for c, n in pairs]
 
     @property


### PR DESCRIPTION
There are 6 `ComponentClasses` in `ARN`. `String.split` takes a `maxsplit` argument which yields a list with at most `maxsplit + 1` elements. We want at most 6 parts, so `maxsplit` should be 5.

In practice, this led to a `TypeError: 'str' is not callable` on line 283, which is now fixed.