### PR TITLE
Allow aws_creds to be loaded from _config

### DIFF
--- a/skew/awsclient.py
+++ b/skew/awsclient.py
@@ -43,6 +43,9 @@ class AWSClient(object):
         self._has_credentials = False
         self.aws_creds = kwargs.get('aws_creds')
         if self.aws_creds is None:
+            self.aws_creds = self._config['accounts'][account_id].get(
+                'credentials')
+        if self.aws_creds is None:
             # no aws_creds, need profile to get creds from ~/.aws/credentials
             self._profile = self._config['accounts'][account_id]['profile']
         self.placebo = kwargs.get('placebo')

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,18 @@ envlist = py26,py27,py33,py34
 [testenv]
 commands = nosetests tests/unit
 deps =
+    httpretty
     nose
     mock
-    httpretty
+    placebo
 
 [testenv:py26]
 commands = nosetests tests/unit
 deps =
-    nose
-    unittest2
     httpretty
-    mock
     importlib
+    mock
+    nose
+    placebo
+    unittest2
+


### PR DESCRIPTION
The current configuration instantiation for skew makes it a bit challenging to use it programmatically as a library. This change allows someone to load AWS credentials into the `skew.config._config` like so:

```
        skew.config._config = {
            'accounts': {
                account: {
                    'credentials': creds
                }
            }
        }
```

Without this change, you can inject `aws_creds` into `skew.scan()` and those kwargs get passed all the way down until you start to iterate resources, at which point things like https://github.com/scopely-devops/skew/blob/develop/skew/resources/aws/__init__.py#L106-L109 attempt to create a new client without the kwargs and things break. :)

Thanks for making this!
