### PR TITLE
wire session factory and partial flyweight optional support

### DIFF
--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -21,6 +21,7 @@ import jmespath
 
 import skew.resources
 from skew.config import get_config
+from skew.awsclient import SkewSessionFactory
 
 LOG = logging.getLogger(__name__)
 DebugFmtString = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
@@ -121,11 +122,15 @@ class Resource(ARNComponent):
         LOG.debug('resource_type=%s, resource_id=%s',
                   resource_type, resource_id)
         resources = []
+
+        session_factory = SkewSessionFactory(region, account, **kwargs)
+
         for resource_type in self.matches(context):
             resource_path = '.'.join([provider, service_name, resource_type])
             resource_cls = skew.resources.find_resource_class(resource_path)
             resources.extend(resource_cls.enumerate(
-                self._arn, region, account, resource_id, **kwargs))
+                session_factory, self._arn, resource_id))
+
         return resources
 
 

--- a/skew/awsclient.py
+++ b/skew/awsclient.py
@@ -78,7 +78,9 @@ class AWSClient(object):
                 pill.record()
             elif self.placebo_mode == 'playback':
                 pill.playback()
-        return session.client(self.service_name, region_name=self.region_name)
+        return session.client(
+            self.service_name,
+            region_name=self.region_name or 'us-east-1')
 
     def call(self, op_name, query=None, **kwargs):
         """
@@ -137,3 +139,14 @@ class AWSClient(object):
 
 def get_awsclient(service_name, region_name, account_id, **kwargs):
     return AWSClient(service_name, region_name, account_id, **kwargs)
+
+
+class SkewSessionFactory(object):
+
+    def __init__(self, region, account, **kwargs):
+        self.region_name = region
+        self.account = account
+        self.kwargs = kwargs
+
+    def get_client(self, service_name):
+        return AWSClient(service_name, self.region_name, self.account, **self.kwargs)

--- a/skew/resources/aws/autoscaling.py
+++ b/skew/resources/aws/autoscaling.py
@@ -31,8 +31,8 @@ class AutoScalingGroup(AWSResource):
         filter_name = 'AutoScalingGroupNames'
         filter_type = 'list'
 
-    def __init__(self, client, data, query=None):
-        super(AutoScalingGroup, self).__init__(client, data, query)
+    def __init__(self, session_factory, client, data, query=None):
+        super(AutoScalingGroup, self).__init__(session_factory, client, data, query)
         self._arn_query = jmespath.compile('AutoScalingGroupARN')
 
     @property
@@ -55,8 +55,8 @@ class LaunchConfiguration(AWSResource):
         filter_name = 'LaunchConfigurationNames'
         filter_type = 'list'
 
-    def __init__(self, client, data, query=None):
-        super(LaunchConfiguration, self).__init__(client, data, query)
+    def __init__(self, session_factory, client, data, query=None):
+        super(LaunchConfiguration, self).__init__(session_factory, client, data, query)
         self._arn_query = jmespath.compile('LaunchConfigurationARN')
 
     @property

--- a/skew/resources/aws/cloudformation.py
+++ b/skew/resources/aws/cloudformation.py
@@ -18,9 +18,10 @@ from skew.resources.aws import AWSResource
 class Stack(AWSResource):
 
     @classmethod
-    def enumerate(cls, arn, region, account, resource_id=None, **kwargs):
-        resources = super(Stack, cls).enumerate(arn, region, account,
-                                                resource_id, **kwargs)
+    def enumerate(cls, session_factory, arn, resource_id=None):
+        resources = super(Stack, cls).enumerate(
+            session_factory, arn, resource_id)
+
         for stack in resources:
             stack.data['Resources'] = []
             for stack_resource in stack:
@@ -47,15 +48,15 @@ class Stack(AWSResource):
         date = 'CreationTime'
         dimension = None
 
-    def __init__(self, client, data, query=None):
-        super(Stack, self).__init__(client, data, query)
+    def __init__(self, session_factory, client, data, query=None):
+        super(Stack, self).__init__(session_factory, client, data, query)
         self._data = data
-        self._resources = []
+        self._resources = None
 
     def __iter__(self):
         detail_op, param_name, detail_path = self.Meta.detail_spec
         params = {param_name: self.id}
-        if not self._resources:
+        if self._resources is None:
             data = self._client.call(detail_op, **params)
             self._resources = jmespath.search(detail_path, data)
         for resource in self._resources:

--- a/skew/resources/aws/dynamodb.py
+++ b/skew/resources/aws/dynamodb.py
@@ -40,8 +40,8 @@ class Table(AWSResource):
         LOG.debug('%s == %s', resource_id, data)
         return resource_id == data
 
-    def __init__(self, client, data, query=None):
-        super(Table, self).__init__(client, data, query)
+    def __init__(self, session_factory, client, data, query=None):
+        super(Table, self).__init__(session_factory, client, data, query)
         self._id = data
         detail_op, param_name, detail_path = self.Meta.detail_spec
         params = {param_name: self.id}

--- a/skew/resources/aws/firehose.py
+++ b/skew/resources/aws/firehose.py
@@ -1,4 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License"). You
+o# Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
 #
@@ -27,8 +27,8 @@ class DeliveryStream(AWSResource):
         date = 'CreateTimestamp'
         dimension = 'DeliveryStreamName'
 
-    def __init__(self, client, data, query=None):
-        super(DeliveryStream, self).__init__(client, data, query)
+    def __init__(self, session_factory, client, data, query=None):
+        super(DeliveryStream, self).__init__(session_factory, client, data, query)
         self._id = data
         detail_op, param_name, detail_path = self.Meta.detail_spec
         params = {param_name: self.id}

--- a/skew/resources/aws/kinesis.py
+++ b/skew/resources/aws/kinesis.py
@@ -29,7 +29,7 @@ class Stream(AWSResource):
         date = None
         dimension = 'StreamName'
 
-    def __init__(self, client, data, query=None):
-        super(Stream, self).__init__(client, data, query)
+    def __init__(self, session_factory, client, data, query=None):
+        super(Stream, self).__init__(session_factory, client, data, query)
         self.data = {self.Meta.id: data}
         self._id = self.data[self.Meta.id]

--- a/skew/resources/aws/lambda.py
+++ b/skew/resources/aws/lambda.py
@@ -23,9 +23,9 @@ LOG = logging.getLogger(__name__)
 class Function(AWSResource):
 
     @classmethod
-    def enumerate(cls, arn, region, account, resource_id=None, **kwargs):
-        resources = super(Function, cls).enumerate(arn, region, account,
-                                                   resource_id, **kwargs)
+    def enumerate(cls, session_factory, arn, resource_id=None):
+        resources = super(Function, cls).enumerate(
+            session_factory, arn, resource_id)
         for r in resources:
             r.data['EventSources'] = []
             kwargs = {'FunctionName': r.data['FunctionName']}

--- a/skew/resources/aws/s3.py
+++ b/skew/resources/aws/s3.py
@@ -23,13 +23,11 @@ class Bucket(AWSResource):
     _location_cache = {}
 
     @classmethod
-    def enumerate(cls, arn, region, account, resource_id=None, **kwargs):
-        resources = super(Bucket, cls).enumerate(arn, region, account,
-                                                 resource_id,
-                                                 **kwargs)
+    def enumerate(cls, session_factory, arn, resource_id=None):
+        resources = super(Bucket, cls).enumerate(
+            session_factory, arn, resource_id)
         region_resources = []
-        if region is None:
-            region = 'us-east-1'
+        region = session_factory.region_name or 'us-east-1'
         for r in resources:
             location = cls._location_cache.get(r.id)
             if location is None:
@@ -57,8 +55,8 @@ class Bucket(AWSResource):
         date = 'CreationDate'
         dimension = None
 
-    def __init__(self, client, data, query=None):
-        super(Bucket, self).__init__(client, data, query)
+    def __init__(self, session_factory, client, data, query=None):
+        super(Bucket, self).__init__(session_factory, client, data, query)
         self._data = data
         self._keys = []
 

--- a/skew/resources/aws/sns.py
+++ b/skew/resources/aws/sns.py
@@ -42,8 +42,8 @@ class Topic(AWSResource):
     def arn(self):
         return self.data.get('TopicArn')
 
-    def __init__(self, client, data, query=None):
-        super(Topic, self).__init__(client, data, query)
+    def __init__(self, session_factory, client, data, query=None):
+        super(Topic, self).__init__(session_factory, client, data, query)
 
         self._id = data['TopicArn'].split(':', 5)[5]
 
@@ -76,14 +76,14 @@ class Subscription(AWSResource):
         return self.data.get('SubscriptionArn')
 
     @classmethod
-    def enumerate(cls, arn, region, account, resource_id=None, **kwargs):
+    def enumerate(cls, session_factory, arn, resource_id=None):
         resources = super(Subscription, cls).enumerate(
-            arn, region, account, resource_id, **kwargs)
+            session_factory, arn, resource_id)
 
         return [r for r in resources if r.id not in cls.invalid_arns]
 
-    def __init__(self, client, data, query=None):
-        super(Subscription, self).__init__(client, data, query)
+    def __init__(self, session_factory, client, data, query=None):
+        super(Subscription, self).__init__(session_factory, client, data, query)
 
         if data['SubscriptionArn'] in self.invalid_arns:
             self._id = 'PendingConfirmation'

--- a/skew/resources/aws/sqs.py
+++ b/skew/resources/aws/sqs.py
@@ -29,8 +29,8 @@ class Queue(AWSResource):
         date = None
         dimension = 'QueueName'
 
-    def __init__(self, client, data, query=None):
-        super(Queue, self).__init__(client, data, query)
+    def __init__(self, session_factory, client, data, query=None):
+        super(Queue, self).__init__(session_factory, client, data, query)
         self.data = {self.Meta.id: data,
                      'QueueName': data.split('/')[-1]}
         self._id = self.data['QueueName']

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -47,7 +47,7 @@ class TestResource(unittest.TestCase):
     def test_resource(self):
         client = skew.awsclient.get_awsclient(
             'ec2', 'us-east-1', '123456789012')
-        resource = FooResource(client, data={'bar': 'bar'})
+        resource = FooResource(None, client, data={'bar': 'bar'})
         self.assertEqual(resource.id, 'bar')
         self.assertEqual(resource.__repr__(),
                          'arn:aws:ec2:us-east-1:123456789012:foo/bar')


### PR DESCRIPTION
not sure wrt to approach here, i've tried a separate query executor class against extant meta models as well, which might be a little nicer, but wanted to try and see what it looked like to modify extant for library usage.

This unifies the client creation behind a passed object (session_factory) through most of the tree. cloudwatch usage is made lazy, as client construction does require reading model files and is noticable in lambda. there's partial support for choosing between flyweight resource classes and raw dictionaries. 

mostly to start a discussion, i'll post a query branch later this week for comparison.
