### PR TITLE
Change region_name to None if empty string

### DIFF
--- a/skew/awsclient.py
+++ b/skew/awsclient.py
@@ -136,4 +136,6 @@ class AWSClient(object):
 
 
 def get_awsclient(service_name, region_name, account_id, **kwargs):
+    if region_name == '':
+        region_name = None
     return AWSClient(service_name, region_name, account_id, **kwargs)


### PR DESCRIPTION
Botocore checks for None as opposed to empty string when trying to generate a default endpoint .  In skew's current form with the way versions are pinned it will not generate endpoints properly for global services when an empty string is passed in recent versions of boto3/botocore.

Current tests fail but since no recent merges have been made its not apparent. This small change should get tests passing and global service endpoints generating properly again.

Resolves #96 
