### PR TITLE
fix hardcoded pyyaml dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requires = [
     'boto3>=1.2.3',
     'six>=1.9.0',
     'python-dateutil>=2.1,<3.0.0',
-    'PyYAML==3.11']
+    'PyYAML>=3.11']
 
 
 here = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
pyyaml release is currently 3.12 and this causes transitive dep resolution issues with others
