### PR TITLE
fix filter and name for security group resource

### DIFF
--- a/skew/resources/aws/ec2.py
+++ b/skew/resources/aws/ec2.py
@@ -42,9 +42,9 @@ class SecurityGroup(AWSResource):
         enum_spec = ('describe_security_groups', 'SecurityGroups', None)
         detail_spec = None
         id = 'GroupId'
-        filter_name = 'GroupNames'
+        filter_name = 'GroupIds'
         filter_type = 'list'
-        name = 'GroupName'
+        name = 'GroupId'
         date = None
         dimension = None
 


### PR DESCRIPTION
Let me know if that wasn’t actually a typo and there’s a reason for it to be like that. Thanks.