### PR TITLE
Fix client creation when service has no region

### DIFF
--- a/skew/awsclient.py
+++ b/skew/awsclient.py
@@ -78,7 +78,8 @@ class AWSClient(object):
                 pill.record()
             elif self.placebo_mode == 'playback':
                 pill.playback()
-        return session.client(self.service_name, region_name=self.region_name)
+        return session.client(self.service_name,
+                              region_name=self.region_name if self.region_name else None)
 
     def call(self, op_name, query=None, **kwargs):
         """


### PR DESCRIPTION
For services which are not bound to a particular region, like IAM or Route53, creating a client with `region_name = ''`fails as described in #103 . This PR fixes this problem by setting `region_name = None` in this case.