### PR TITLE
Update tags_spec for Cloudfront.Distribution

### DIFF
--- a/skew/resources/aws/cloudfront.py
+++ b/skew/resources/aws/cloudfront.py
@@ -23,6 +23,8 @@ class Distribution(CloudfrontResource):
         enum_spec = ('list_distributions', 'DistributionList.Items[]', None)
         detail_spec = None
         id = 'Id'
+        tags_spec = ('list_tags_for_resource', 'Tags.Items[]',
+                     'Resource', 'arn')
         name = 'DomainName'
         filter_name = None
         date = 'LastModifiedTime'


### PR DESCRIPTION
We can now retrieve Cloudfront.Distributions tag list.