### PR TITLE
Update tags_spec for DynamoDB.Table

### DIFF
--- a/skew/resources/aws/dynamodb.py
+++ b/skew/resources/aws/dynamodb.py
@@ -30,6 +30,8 @@ class Table(AWSResource):
         enum_spec = ('list_tables', 'TableNames', None)
         detail_spec = ('describe_table', 'TableName', 'Table')
         id = 'Table'
+        tags_spec = ('list_tags_of_resource', 'Tags[]',
+                     'ResourceArn', 'arn')
         filter_name = None
         name = 'TableName'
         date = 'CreationDateTime'


### PR DESCRIPTION
We can now retrieve DynamoDB.Table tag list.
Note: if boto3's documentation (http://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#DynamoDB.Client.list_tags_of_resource)
and AWS API's documentation (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTagsOfResource.html),
the API call is described as having the "NextToken" mechanism implemented.
As far as I could see, skew's implementation relies on boto3's
can_paginate / get_paginator to handle this.
But it seems that boto3's latest version do not have a paginator
for the list_tags_of_resource() call.
I may have understood all this wrongly of course, but if it
were true, we *could* loose some of the tags.