### PR TITLE
Update tags_spec for Elasticache clusters and snapshots

### DIFF
--- a/skew/resources/aws/elasticache.py
+++ b/skew/resources/aws/elasticache.py
@@ -30,6 +30,13 @@ class Cluster(AWSResource):
         date = 'CacheClusterCreateTime'
         dimension = 'CacheClusterId'
 
+    @property
+    def arn(self):
+        return 'arn:aws:%s:%s:%s:%s:%s' % (
+            self._client.service_name,
+            self._client.region_name,
+            self._client.account_id, self.resourcetype, self.id)
+
 
 class SubnetGroup(AWSResource):
 
@@ -60,3 +67,10 @@ class Snapshot(AWSResource):
         name = 'SnapshotName'
         date = 'StartTime'
         dimension = None
+
+    @property
+    def arn(self):
+        return 'arn:aws:%s:%s:%s:%s:%s' % (
+            self._client.service_name,
+            self._client.region_name,
+            self._client.account_id, self.resourcetype, self.id)

--- a/skew/resources/aws/elasticache.py
+++ b/skew/resources/aws/elasticache.py
@@ -24,6 +24,8 @@ class Cluster(AWSResource):
                      'CacheClusters[]', None)
         detail_spec = None
         id = 'CacheClusterId'
+        tags_spec = ('list_tags_for_resource', 'TagList',
+                     'ResourceName', 'arn')
         filter_name = 'CacheClusterId'
         filter_type = 'scalar'
         name = 'CacheClusterId'
@@ -62,6 +64,8 @@ class Snapshot(AWSResource):
         enum_spec = ('describe_snapshots', 'Snapshots', None)
         detail_spec = None
         id = 'SnapshotName'
+        tags_spec = ('list_tags_for_resource', 'TagList',
+                     'ResourceName', 'arn')
         filter_name = 'SnapshotName'
         filter_type = 'scalar'
         name = 'SnapshotName'


### PR DESCRIPTION
We can now retrieve Elasticache clusters and snapshots tag list. This patch
builds upon an existing patch from @Gifflen :
https://github.com/ryandub/skew/commit/95b90ae0b57665d56813ba851e02b1f82ba84295