### PR TITLE
Update tags_spec for Lambda.functions

### DIFF
--- a/skew/resources/aws/__init__.py
+++ b/skew/resources/aws/__init__.py
@@ -160,13 +160,17 @@ class AWSResource(Resource):
                 LOG.debug(self.data['Tags'])
 
             if 'Tags' in self.data:
-                for kvpair in self.data['Tags']:
-                    if kvpair['Key'] in self._tags:
-                        if not isinstance(self._tags[kvpair['Key']], list):
-                            self._tags[kvpair['Key']] = [self._tags[kvpair['Key']]]
-                        self._tags[kvpair['Key']].append(kvpair['Value'])
-                    else:
-                        self._tags[kvpair['Key']] = kvpair['Value']
+                _tags = self.data['Tags']
+                if isinstance(_tags, list):
+                    for kvpair in _tags:
+                        if kvpair['Key'] in self._tags:
+                            if not isinstance(self._tags[kvpair['Key']], list):
+                                self._tags[kvpair['Key']] = [self._tags[kvpair['Key']]]
+                            self._tags[kvpair['Key']].append(kvpair['Value'])
+                        else:
+                            self._tags[kvpair['Key']] = kvpair['Value']
+                elif isinstance(_tags, dict):
+                    self._tags = _tags
         return self._tags
 
     def find_metric(self, metric_name):

--- a/skew/resources/aws/lambda.py
+++ b/skew/resources/aws/lambda.py
@@ -44,6 +44,8 @@ class Function(AWSResource):
         name = 'FunctionName'
         date = 'LastModified'
         dimension = 'FunctionName'
+        tags_spec = ('list_tags', 'Tags',
+                     'Resource', 'arn')
 
     @classmethod
     def filter(cls, arn, resource_id, data):


### PR DESCRIPTION
We can now retrieve Lambda.functions tag list.
A change was needed to handle the format of the tag list returned
by the Lambda list_tags function.