### PR TITLE
Update tags_spec for Kinesis.Stream

### DIFF
--- a/skew/resources/aws/kinesis.py
+++ b/skew/resources/aws/kinesis.py
@@ -28,6 +28,8 @@ class Stream(AWSResource):
         name = 'StreamName'
         date = None
         dimension = 'StreamName'
+        tags_spec = ('list_tags_for_stream', 'Tags[]',
+                     'StreamName', 'id')
 
     def __init__(self, client, data, query=None):
         super(Stream, self).__init__(client, data, query)


### PR DESCRIPTION
We can now retrieve Kinesis.Stream tag list.
Note: if boto3's documentation (http://boto3.readthedocs.io/en/latest/reference/services/kinesis.html#Kinesis.Client.list_tags_for_stream)
and AWS API's documentation (https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListTagsForStream.html)
the API call is described as having a "NextToken"-like mechanism implemented.
As far as I could see, skew's implementation relies on boto3's
can_paginate / get_paginator to handle this.
But it seems that boto3's latest version do not have a paginator
for the list_tags_for_stream() call.
I may have understood all this wrongly of course, but if it
were true, we *could* loose some of the tags.