### PR TITLE
Update tags_spec for Route53 hostedzone and healthcheck

### DIFF
--- a/skew/resources/aws/__init__.py
+++ b/skew/resources/aws/__init__.py
@@ -64,6 +64,10 @@ class AWSResource(Resource):
         (this is not always the same as filter_name, e.g. RDS)
       * the value of the parameter to send to identify the specific resource
         (this is not always the same as the id, e.g. RDS)
+      * [OPTIONAL] the fifth parameter is a dict containing the constants
+        needed to the call of the operation, in addition to the parameter
+        used to identify the specific resource (e.g. needed for Route53).
+        Those constants are expressed in a dict of key, value pairs.
     * detail_spec - Some services provide only summary information in the
       list or describe method and require you to make another request to get
       the detailed info for a specific resource.  If that is the case, this
@@ -147,13 +151,15 @@ class AWSResource(Resource):
 
             if hasattr(self.Meta, 'tags_spec') and (self.Meta.tags_spec is not None):
                 LOG.debug('have a tags_spec')
-                method, path, param_name, param_value = self.Meta.tags_spec
+                method, path, param_name, param_value = self.Meta.tags_spec[:4]
                 kwargs = {}
                 filter_type = getattr(self.Meta, 'filter_type', None)
                 if filter_type == 'list':
                     kwargs = {param_name: [getattr(self, param_value)]}
                 else:
                     kwargs = {param_name: getattr(self, param_value)}
+                if len(self.Meta.tags_spec) > 4:
+                    kwargs.update(self.Meta.tags_spec[4])
                 LOG.debug('fetching tags')
                 self.data['Tags'] = self._client.call(
                     method, query=path, **kwargs)

--- a/skew/resources/aws/route53.py
+++ b/skew/resources/aws/route53.py
@@ -35,6 +35,8 @@ class HostedZone(Route53Resource):
         name = 'Name'
         date = None
         dimension = None
+        tags_spec = ('list_tags_for_resource', 'ResourceTagSet.Tags[]',
+                     'ResourceId', 'id', {'ResourceType': 'hostedzone'})
 
     @property
     def id(self):
@@ -53,6 +55,8 @@ class HealthCheck(Route53Resource):
         name = None
         date = None
         dimension = None
+        tags_spec = ('list_tags_for_resource', 'ResourceTagSet.Tags[]',
+                     'ResourceId', 'id', {'ResourceType': 'healthcheck'})
 
 
 class ResourceRecordSet(Route53Resource):


### PR DESCRIPTION
We can now retrieve Route53.hostedzone and Route53.healthcheck tag list.

A change was needed in the format of tags_spec, a fifth (optional)
parameter was added to handle the optional parameters to the call
to Route53's list_tags_for_resource() function.