### PR TITLE
Update tags_spec for S3.bucket

### DIFF
--- a/skew/awsclient.py
+++ b/skew/awsclient.py
@@ -129,6 +129,8 @@ class AWSClient(object):
                         time.sleep(1)
                     elif 'AccessDenied' in str(e):
                         done = True
+                    elif 'NoSuchTagSet' in str(e):
+                        done = True
                 except Exception:
                     done = True
         if query:

--- a/skew/resources/aws/s3.py
+++ b/skew/resources/aws/s3.py
@@ -56,6 +56,8 @@ class Bucket(AWSResource):
         name = 'BucketName'
         date = 'CreationDate'
         dimension = None
+        tags_spec = ('get_bucket_tagging', 'TagSet[]',
+                     'Bucket', 'id')
 
     def __init__(self, client, data, query=None):
         super(Bucket, self).__init__(client, data, query)


### PR DESCRIPTION
We can now retrieve S3.bucket tag list.
A change was needed to handle the return of the S3 API when
there is no tag - See boto/boto3#341