### PR TITLE
Use yaml.safe_load

### DIFF
--- a/skew/config.py
+++ b/skew/config.py
@@ -34,5 +34,5 @@ def get_config():
         if not os.path.exists(path):
             raise ConfigNotFoundError('Unable to find skew config file')
         with open(path) as config_file:
-            _config = yaml.load(config_file)
+            _config = yaml.safe_load(config_file)
     return _config


### PR DESCRIPTION
Addressing https://nvd.nist.gov/vuln/detail/CVE-2017-18342; cannot just update pyyaml because the new version drops certain Python versions