### PR TITLE
Fix when a resource without provider is provided

### DIFF
--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -105,11 +105,11 @@ class Resource(ARNComponent):
 
     def choices(self, context=None):
         if context:
-            service = context[2]
+            provider, service = context[1:3]
         else:
             service = self._arn.service.pattern
-        all_resources = skew.resources.all_types(
-            self._arn.provider.pattern, service)
+            provider = self._arn.provider.pattern
+        all_resources = skew.resources.all_types(provider, service)
         if not all_resources:
             all_resources = ['*']
         return all_resources

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -316,3 +316,14 @@ class TestARN(unittest.TestCase):
                          'arn:aws:logs:us-east-1:123456789012:log-group:CloudTrail/DefaultLogGroup:*')
         print(l[0].tags)
         self.assertEqual(l[0].tags['TestKey'], 'TestValue')
+
+    def test_no_provider(self):
+        placebo_cfg = {
+            'placebo': placebo,
+            'placebo_dir': self._get_response_path('trail'),
+            'placebo_mode': 'playback'}
+        arn = scan(
+                    '::cloudtrail:us-east-1:123456789012:trail/*',
+                   **placebo_cfg)
+        l = list(arn)
+        self.assertEqual(len(l), 1)


### PR DESCRIPTION
skew.scan('::sqs:::/') fails with this:

```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    for resource in skew.scan(uri):
  File "/Users/farid/repos/skew/skew/arn/__init__.py", line 327, in __iter__
    for scheme in self.scheme.enumerate(context, **self.kwargs):
  File "/Users/farid/repos/skew/skew/arn/__init__.py", line 252, in enumerate
    context, **kwargs):
  File "/Users/farid/repos/skew/skew/arn/__init__.py", line 237, in enumerate
    context, **kwargs):
  File "/Users/farid/repos/skew/skew/arn/__init__.py", line 222, in enumerate
    context, **kwargs):
  File "/Users/farid/repos/skew/skew/arn/__init__.py", line 203, in enumerate
    context, **kwargs):
  File "/Users/farid/repos/skew/skew/arn/__init__.py", line 146, in enumerate
    context, **kwargs):
  File "/Users/farid/repos/skew/skew/arn/__init__.py", line 126, in enumerate
    resource_cls = skew.resources.find_resource_class(resource_path)
  File "/Users/farid/repos/skew/skew/resources/__init__.py", line 104, in find_resource_class
    class_path = ResourceTypes[resource_path]
KeyError: 'aws.sqs.*'
```