### PR TITLE
Fix ec2 key pair resource

### DIFF
--- a/skew/resources/aws/ec2.py
+++ b/skew/resources/aws/ec2.py
@@ -56,7 +56,7 @@ class KeyPair(AWSResource):
         type = 'key-pair'
         enum_spec = ('describe_key_pairs', 'KeyPairs', None)
         detail_spec = None
-        id = 'KeyName'
+        id = 'KeyPairId'
         filter_name = 'KeyNames'
         name = 'KeyName'
         date = None

--- a/tests/unit/responses/keypairs/ec2.DescribeKeyPairs_1.json
+++ b/tests/unit/responses/keypairs/ec2.DescribeKeyPairs_1.json
@@ -3,10 +3,12 @@
     "data": {
         "KeyPairs": [
             {
+                "KeyPairId": "key-1274ea12942819e24",
                 "KeyName": "admin", 
                 "KeyFingerprint": "85:83:08:25:fa:96:45:ea:c9:15:04:12:af:45:3f:c0:ef:e8:b8:ce"
             }, 
             {
+                "KeyPairId": "key-1274ea12942819e25",
                 "KeyName": "FooBar", 
                 "KeyFingerprint": "9b:02:68:c2:ff:32:38:1a:49:ec:c4:b5:b3:98:36:cf:cd:1f:73:cc"
             }

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -104,8 +104,10 @@ class TestARN(unittest.TestCase):
                    debug=True, **placebo_cfg)
         l = list(arn)
         self.assertEqual(len(l), 2)
-        self.assertEqual(l[0].id, 'admin')
-        self.assertEqual(l[1].id, 'FooBar')
+        self.assertEqual(l[0].id, 'key-1274ea12942819e24')
+        self.assertEqual(l[1].id, 'key-1274ea12942819e25')
+        self.assertEqual(l[0].name, 'admin')
+        self.assertEqual(l[1].name, 'FooBar')
         self.assertEqual(
             l[0].data['KeyFingerprint'],
             "85:83:08:25:fa:96:45:ea:c9:15:04:12:af:45:3f:c0:ef:e8:b8:ce")


### PR DESCRIPTION
I stumbled across a small mistake when fetching ARNs for EC2 keypairs, the correct ARN pattern is :
`arn:aws:ec2:REGION:ACCOUNT-ID:key-pair/KEY-ID` instead of `arn:aws:ec2:REGION:ACCOUNT-ID:key-pair/KEY-NAME`.
This PR fixes this issue by using the `KeyPairId` returned by `describe_key_pairs`.