### PR TITLE
Fix cloudwatch-alarm arn pattern

### DIFF
--- a/skew/resources/aws/cloudwatch.py
+++ b/skew/resources/aws/cloudwatch.py
@@ -24,13 +24,21 @@ class Alarm(AWSResource):
         service = 'cloudwatch'
         type = 'alarm'
         enum_spec = ('describe_alarms', 'MetricAlarms', None)
-        id = 'AlarmArn'
+        id = 'AlarmName'
         filter_name = 'AlarmNames'
         filter_type = 'list'
         detail_spec = None
         name = 'AlarmName'
         date = 'AlarmConfigurationUpdatedTimestamp'
         dimension = None
+
+    @property
+    def arn(self):
+        return 'arn:aws:%s:%s:%s:%s:%s' % (
+            self._client.service_name,
+            self._client.region_name,
+            self._client.account_id,
+            self.resourcetype, self.id)
 
 
 class LogGroup(AWSResource):
@@ -41,13 +49,13 @@ class LogGroup(AWSResource):
         enum_spec = ('describe_log_groups', 'logGroups[]', None)
         attr_spec = [
             ('describe_log_streams', 'logGroupName',
-                'logStreams', 'logStreams'),
+             'logStreams', 'logStreams'),
             ('describe_metric_filters', 'logGroupName',
-                'metricFilters', 'metricFilters'),
+             'metricFilters', 'metricFilters'),
             ('describe_subscription_filters', 'logGroupName',
-                'subscriptionFilters', 'subscriptionFilters'),
+             'subscriptionFilters', 'subscriptionFilters'),
             ('describe_queries', 'logGroupName',
-                'queries', 'queries'),
+             'queries', 'queries'),
         ]
         detail_spec = None
         id = 'logGroupName'

--- a/tests/unit/responses/alarms/monitoring.DescribeAlarms_1.json
+++ b/tests/unit/responses/alarms/monitoring.DescribeAlarms_1.json
@@ -1,0 +1,38 @@
+{
+  "status_code": 200,
+  "data": {
+    "MetricAlarms": [
+      {
+        "AlarmName": "some-alarm",
+        "AlarmArn": "arn:aws:cloudwatch:us-east-1:123456789012:alarm:some-alarm",
+        "AlarmConfigurationUpdatedTimestamp": "2020-06-20T13:09:22.983Z",
+        "ActionsEnabled": true,
+        "OKActions": [],
+        "AlarmActions": [
+          "arn:aws:sns:us-east-1:123456789012:Default_CloudWatch_Alarms_Topic"
+        ],
+        "InsufficientDataActions": [],
+        "StateValue": "OK",
+        "StateReason": "Threshold Crossed: 1 out of the last 1 datapoints [0.043371 (25/06/20 13:04:00)] was not greater than the threshold (10000.0) (minimum 1 datapoint for ALARM -> OK transition).",
+        "StateReasonData": "{\"version\":\"1.0\",\"queryDate\":\"2020-06-25T13:09:47.694+0000\",\"startDate\":\"2020-06-25T13:04:00.000+0000\",\"statistic\":\"Average\",\"period\":300,\"recentDatapoints\":[0.043371],\"threshold\":10000.0}",
+        "StateUpdatedTimestamp": "2020-06-25T13:09:47.695Z",
+        "MetricName": "CPUCreditUsage",
+        "Namespace": "AWS/EC2",
+        "Statistic": "Average",
+        "Dimensions": [
+          {
+            "Name": "InstanceId",
+            "Value": "i-04ca6c180a3426c1b"
+          }
+        ],
+        "Period": 300,
+        "EvaluationPeriods": 1,
+        "DatapointsToAlarm": 1,
+        "Threshold": 10000.0,
+        "ComparisonOperator": "GreaterThanThreshold",
+        "TreatMissingData": "missing"
+      }
+    ],
+    "CompositeAlarms": []
+  }
+}

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -329,3 +329,17 @@ class TestARN(unittest.TestCase):
                    **placebo_cfg)
         l = list(arn)
         self.assertEqual(len(l), 1)
+
+    def test_alarm(self):
+        placebo_cfg = {
+            'placebo': placebo,
+            'placebo_dir': self._get_response_path('alarms'),
+            'placebo_mode': 'playback'}
+        arn = scan(
+            'arn:aws:cloudwatch:us-east-1:123456789012:alarm/*',
+            **placebo_cfg)
+        l = list(arn)
+        self.assertEqual(len(l), 1)
+        self.assertEqual(l[0].arn, 'arn:aws:cloudwatch:us-east-1:123456789012:alarm:some-alarm')
+        self.assertEqual(l[0].data['AlarmArn'],
+                         'arn:aws:cloudwatch:us-east-1:123456789012:alarm:some-alarm')


### PR DESCRIPTION
Hi,
this PR fixes wrong cloudwatch alarm ARNs. 
The whole ARN was appended again to the arn string due to `id = 'AlarmArn' `.
Correct ARN pattern is: 
arn:aws:cloudwatch:REGION:ACCOUNT_ID:alarm:ALARM_NAME
Therefore those changes also override the ARN property provided in the Resource class ( to remove the `/`)