### PR TITLE
Fix customer gateway

### DIFF
--- a/skew/resources/aws/ec2.py
+++ b/skew/resources/aws/ec2.py
@@ -181,7 +181,7 @@ class CustomerGateway(AWSResource):
     class Meta(object):
         service = 'ec2'
         type = 'customer-gateway'
-        enum_spec = ('describe_customer_gateways', 'CustomerGateway', None)
+        enum_spec = ('describe_customer_gateways', 'CustomerGateways', None)
         detail_spec = None
         id = 'CustomerGatewayId'
         filter_name = 'CustomerGatewayIds'

--- a/tests/unit/responses/customergateways/ec2.DescribeCustomerGateways_1.json
+++ b/tests/unit/responses/customergateways/ec2.DescribeCustomerGateways_1.json
@@ -1,0 +1,20 @@
+{
+  "status_code": 200,
+  "data": {
+    "CustomerGateways": [
+      {
+        "BgpAsn": "65000",
+        "CustomerGatewayId": "cgw-030d9af8cdbcdc12f",
+        "IpAddress": "1.1.1.1",
+        "State": "available",
+        "Type": "ipsec.1",
+        "Tags": [
+          {
+            "Key": "Env",
+            "Value": "Prod"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -343,3 +343,17 @@ class TestARN(unittest.TestCase):
         self.assertEqual(l[0].arn, 'arn:aws:cloudwatch:us-east-1:123456789012:alarm:some-alarm')
         self.assertEqual(l[0].data['AlarmArn'],
                          'arn:aws:cloudwatch:us-east-1:123456789012:alarm:some-alarm')
+
+    def test_customer_gateway(self):
+        placebo_cfg = {
+            'placebo': placebo,
+            'placebo_dir': self._get_response_path('customergateways'),
+            'placebo_mode': 'playback'}
+        arn = scan(
+            'arn:aws:ec2:us-east-1:123456789012:customer-gateway/*',
+            **placebo_cfg)
+        l = list(arn)
+        self.assertEqual(len(l), 1)
+        self.assertEqual(l[0].arn, 'arn:aws:ec2:us-east-1:123456789012:customer-gateway/cgw-030d9af8cdbcdc12f')
+        self.assertEqual(l[0].data['CustomerGatewayId'],
+                         'cgw-030d9af8cdbcdc12f')


### PR DESCRIPTION
Hi, 
customer gateways were not returned by the scan operation because the API return dict has changed.
The describe-customer-gateways call now returns a dict with key  `CustomerGateways` instead of `CustomerGateway`.
