### PR TITLE
Fix-log-group-arn

### DIFF
--- a/skew/resources/aws/cloudwatch.py
+++ b/skew/resources/aws/cloudwatch.py
@@ -89,3 +89,10 @@ class LogGroup(AWSResource):
     @property
     def logGroupName(self):
         return self.data.get('logGroupName')
+
+    @property
+    def arn(self):
+        return 'arn:aws:%s:%s:%s:%s:%s' % (
+            self._client.service_name,
+            self._client.region_name,
+            self._client.account_id, self.resourcetype, self.id)

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -281,7 +281,7 @@ class TestARN(unittest.TestCase):
                    **placebo_cfg)
         l = list(arn)
         self.assertEqual(len(l), 1)
-        self.assertEqual(l[0].arn, 'arn:aws:logs:us-east-1:123456789012:log-group/CloudTrail/DefaultLogGroup')
+        self.assertEqual(l[0].arn, 'arn:aws:logs:us-east-1:123456789012:log-group:CloudTrail/DefaultLogGroup')
         self.assertEqual(l[0].data['logGroupName'], 'CloudTrail/DefaultLogGroup')
         self.assertEqual(l[0].tags['TestKey'], 'TestValue')
         self.assertEqual(l[0].data['logStreams'][0]['logStreamName'], '123456789012_CloudTrail_us-east-1')


### PR DESCRIPTION
Use `:` instead of `/` as a separator between log-group and the given log-group name as specified in [AWS docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazoncloudwatchlogs.html).