### PR TITLE
Fix-elasticbeanstalk-env #155

### DIFF
--- a/skew/resources/aws/elasticbeanstalk.py
+++ b/skew/resources/aws/elasticbeanstalk.py
@@ -13,7 +13,6 @@ from skew.resources.aws import AWSResource
 
 
 class Application(AWSResource):
-
     class Meta(object):
         service = 'elasticbeanstalk'
         type = 'application'
@@ -26,8 +25,8 @@ class Application(AWSResource):
         date = None
         dimension = None
 
-class Environment(AWSResource):
 
+class Environment(AWSResource):
     class Meta(object):
         service = 'elasticbeanstalk'
         type = 'environment'
@@ -39,3 +38,14 @@ class Environment(AWSResource):
         name = 'EnvironmentName'
         date = None
         dimension = None
+
+    @property
+    def arn(self):
+        return 'arn:aws:%s:%s:%s:%s/%s/%s' % (
+            self._client.service_name,
+            self._client.region_name,
+            self._client.account_id,
+            self.resourcetype,
+            self.data['ApplicationName'],
+            self.id
+        )

--- a/tests/unit/responses/environments/elasticbeanstalk.DescribeEnvironments_1.json
+++ b/tests/unit/responses/environments/elasticbeanstalk.DescribeEnvironments_1.json
@@ -1,0 +1,30 @@
+{
+  "status_code": 200,
+  "data": {
+    "Environments": [
+      {
+        "EnvironmentName": "Env1",
+        "EnvironmentId": "e-abc32nm323",
+        "ApplicationName": "sample-application",
+        "VersionLabel": "Sample Application",
+        "SolutionStackName": "64bit Amazon Linux 2 v3.0.3 running Docker",
+        "PlatformArn": "arn:aws:elasticbeanstalk:us-west-2::platform/Docker running on 64bit Amazon Linux 2/3.0.3",
+        "EndpointURL": "111.111.111.111",
+        "CNAME": "Env1.eba-2dmwpyrc.us-west-2.elasticbeanstalk.com",
+        "DateCreated": "2020-05-18T14:36:31.201Z",
+        "DateUpdated": "2020-04-24T21:11:56.759Z",
+        "Status": "Ready",
+        "AbortableOperationInProgress": false,
+        "Health": "Green",
+        "HealthStatus": "Ok",
+        "Tier": {
+          "Name": "WebServer",
+          "Type": "Standard",
+          "Version": "1.0"
+        },
+        "EnvironmentLinks": [],
+        "EnvironmentArn": "arn:aws:elasticbeanstalk:us-west-2:123456789012:environment/sample-application/Env1"
+      }
+    ]
+  }
+}

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -357,3 +357,16 @@ class TestARN(unittest.TestCase):
         self.assertEqual(l[0].arn, 'arn:aws:ec2:us-east-1:123456789012:customer-gateway/cgw-030d9af8cdbcdc12f')
         self.assertEqual(l[0].data['CustomerGatewayId'],
                          'cgw-030d9af8cdbcdc12f')
+
+    def test_beanstalk_environments(self):
+        placebo_cfg = {
+            'placebo': placebo,
+            'placebo_dir': self._get_response_path('environments'),
+            'placebo_mode': 'playback'}
+        arn = scan('arn:aws:elasticbeanstalk:us-west-2:123456789012:environment/*',
+                   **placebo_cfg)
+        l = list(arn)
+        r = l[0]
+        self.assertEqual(r.data['EnvironmentName'], "Env1")
+        self.assertEqual(r.arn, "arn:aws:elasticbeanstalk:us-west-2:123456789012:environment/sample-application/Env1")
+        self.assertEqual(r.data['ApplicationName'], "sample-application")


### PR DESCRIPTION
Use ApplicationName returned in `describe_environments` to build proper ARN.
Old:
`arn:aws:elasticbeanstalk:REGION:ACCOUNT-ID:environment/ENVIRONMENT-NAME`
New:
`arn:aws:elasticbeanstalk:REGION:ACCOUNT-ID:environment/APPLICATION-NAME/ENVIRONMENT-NAME`