### PR TITLE
WIP: Add elbv2

### DIFF
--- a/skew/resources/__init__.py
+++ b/skew/resources/__init__.py
@@ -49,6 +49,7 @@ ResourceTypes = {
     'aws.elasticache.snapshot': 'aws.elasticache.Snapshot',
     'aws.elasticbeanstalk.application': 'aws.elasticbeanstalk.Application',
     'aws.elasticbeanstalk.environment': 'aws.elasticbeanstalk.Environment',
+    'aws.elasticloadbalancing.loadbalancer': 'aws.elb.LoadBalancerV2',
     'aws.elb.loadbalancer': 'aws.elb.LoadBalancer',
     'aws.es.domain': 'aws.es.ElasticsearchDomain',
     'aws.firehose.deliverystream': 'aws.firehose.DeliveryStream',

--- a/skew/resources/aws/elb.py
+++ b/skew/resources/aws/elb.py
@@ -28,9 +28,9 @@ class LoadBalancer(AWSResource):
         detail_spec = None
         attr_spec = [
             ('describe_load_balancer_attributes', 'LoadBalancerName',
-                'LoadBalancerAttributes', 'LoadBalancerAttributes'),
+             'LoadBalancerAttributes', 'LoadBalancerAttributes'),
             ('describe_load_balancer_policies', 'LoadBalancerName',
-                'PolicyDescriptions', 'PolicyDescriptions'),
+             'PolicyDescriptions', 'PolicyDescriptions'),
         ]
         id = 'LoadBalancerName'
         filter_name = 'LoadBalancerNames'
@@ -57,3 +57,28 @@ class LoadBalancer(AWSResource):
                 del data['ResponseMetadata']
             self.data[detail_key] = data
             LOG.debug(data)
+
+
+class LoadBalancerV2(AWSResource):
+
+    class Meta(object):
+        service = 'elbv2'
+        type = 'loadbalancer'
+        enum_spec = ('describe_load_balancers',
+                     'LoadBalancers', None)
+        detail_spec = None
+        id = 'LoadBalancerArn'
+        filter_name = 'LoadBalancerNames'
+        filter_type = 'list'
+        name = 'DNSName'
+        date = 'CreatedTime'
+        dimension = 'LoadBalancerName'
+        tags_spec = ('describe_tags', 'TagDescriptions[].Tags[]',
+                     'ResourceArn', 'id')
+
+
+    @property
+    def arn(self):
+        return '%s' % (
+            self.id
+        )

--- a/skew/resources/aws/elb.py
+++ b/skew/resources/aws/elb.py
@@ -58,6 +58,13 @@ class LoadBalancer(AWSResource):
             self.data[detail_key] = data
             LOG.debug(data)
 
+    @property
+    def arn(self):
+        return 'arn:aws:elasticloadbalancing:%s:%s:%s/%s' % (
+            self._client.region_name,
+            self._client.account_id,
+            self.resourcetype, self.id)
+
 
 class LoadBalancerV2(AWSResource):
 
@@ -75,7 +82,6 @@ class LoadBalancerV2(AWSResource):
         dimension = 'LoadBalancerName'
         tags_spec = ('describe_tags', 'TagDescriptions[].Tags[]',
                      'ResourceArn', 'id')
-
 
     @property
     def arn(self):

--- a/tests/unit/responses/elbsv2/elasticloadbalancing.DescribeLoadBalancers_1.json
+++ b/tests/unit/responses/elbsv2/elasticloadbalancing.DescribeLoadBalancers_1.json
@@ -1,0 +1,36 @@
+{
+  "status_code": 200,
+  "data": {
+    "LoadBalancers": [
+      {
+        "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:1111111111:loadbalancer/app/some-loadbalancer-v2/2277c8dd3340a0e3",
+        "DNSName": "internal-some-loadbalancer-v2-1835498223.us-east-1.elb.amazonaws.com",
+        "CanonicalHostedZoneId": "Z215JYRZR1TBD5",
+        "CreatedTime": "2020-08-24T11:21:15.360Z",
+        "LoadBalancerName": "some-loadbalancer-v2",
+        "Scheme": "internal",
+        "VpcId": "vpc-a57fafce",
+        "State": {
+          "Code": "active"
+        },
+        "Type": "application",
+        "AvailabilityZones": [
+          {
+            "ZoneName": "us-east-1b",
+            "SubnetId": "subnet-2921d754",
+            "LoadBalancerAddresses": []
+          },
+          {
+            "ZoneName": "us-east-1a",
+            "SubnetId": "subnet-7fa21911",
+            "LoadBalancerAddresses": []
+          }
+        ],
+        "SecurityGroups": [
+          "sg-3703b84d"
+        ],
+        "IpAddressType": "ipv4"
+      }
+    ]
+  }
+}

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -357,3 +357,16 @@ class TestARN(unittest.TestCase):
         self.assertEqual(l[0].arn, 'arn:aws:ec2:us-east-1:123456789012:customer-gateway/cgw-030d9af8cdbcdc12f')
         self.assertEqual(l[0].data['CustomerGatewayId'],
                          'cgw-030d9af8cdbcdc12f')
+
+    def test_elb_loadbalancer_v2(self):
+        placebo_cfg = {
+            'placebo': placebo,
+            'placebo_dir': self._get_response_path('elbsv2'),
+            'placebo_mode': 'playback'}
+        arn = scan('arn:aws:elasticloadbalancing:us-east-1:1111111111:loadbalancer/*',
+                   **placebo_cfg)
+        l = list(arn)
+        self.assertEqual(len(l), 1)
+        self.assertEqual(l[0].arn, 'arn:aws:elasticloadbalancing:us-east-1:1111111111:loadbalancer/app/some-loadbalancer-v2/2277c8dd3340a0e3')
+        self.assertEqual(l[0].data['DNSName'], 'internal-some-loadbalancer-v2-1835498223.us-east-1.elb.amazonaws.com')
+        self.assertEqual(l[0].tags['Name'], 'some-loadbalancer-v2')

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -131,7 +131,7 @@ class TestARN(unittest.TestCase):
                    **placebo_cfg)
         l = list(arn)
         self.assertEqual(len(l), 1)
-        self.assertEqual(l[0].arn, 'arn:aws:elb:us-east-1:123456789012:loadbalancer/example')
+        self.assertEqual(l[0].arn, 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/example')
         self.assertEqual(l[0].data['DNSName'], 'example-1111111111.us-east-1.elb.amazonaws.com')
         self.assertEqual(l[0].tags['Name'], 'example-web')
         self.assertEqual(l[0].data['LoadBalancerAttributes']['CrossZoneLoadBalancing']['Enabled'], False)
@@ -370,3 +370,4 @@ class TestARN(unittest.TestCase):
         self.assertEqual(l[0].arn, 'arn:aws:elasticloadbalancing:us-east-1:1111111111:loadbalancer/app/some-loadbalancer-v2/2277c8dd3340a0e3')
         self.assertEqual(l[0].data['DNSName'], 'internal-some-loadbalancer-v2-1835498223.us-east-1.elb.amazonaws.com')
         self.assertEqual(l[0].tags['Name'], 'some-loadbalancer-v2')
+

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -61,4 +61,4 @@ class TestResource(unittest.TestCase):
 
     def test_all_services(self):
         all_providers = skew.resources.all_services('aws')
-        self.assertEqual(len(all_providers), 24)
+        self.assertEqual(len(all_providers), 25)


### PR DESCRIPTION
Im trying to support both loadbalancer versions.
Both have `elasticloadbalancing` in their ARN. 
How shall we handle this case ? 
Should we just manipulate the  output ARN of elbv1 resources and leave the "entry" pattern at "elb" ?
I think there is currently no way to support mapping elasticloadbalancing to two different classes `skew/resources/__init__.py`

Futhermore I'm struggling a bit to get the elbv2 test working, am I doing something wrong in the placebo setup?
Thanks!