### PR TITLE
Ec2 fixes

### DIFF
--- a/skew/resources/aws/ec2.py
+++ b/skew/resources/aws/ec2.py
@@ -257,7 +257,7 @@ class VpcPeeringConnection(AWSResource):
         service = 'ec2'
         type = 'vpc-peering-connection'
         enum_spec = ('describe_vpc_peering_connections',
-                     'VpcPeeringConnection', None)
+                     'VpcPeeringConnections', None)
         detail_spec = None
         id = 'VpcPeeringConnectionId'
         filter_name = 'VpcPeeringConnectionIds'

--- a/skew/resources/aws/ec2.py
+++ b/skew/resources/aws/ec2.py
@@ -70,7 +70,7 @@ class Address(AWSResource):
         type = 'address'
         enum_spec = ('describe_addresses', 'Addresses', None)
         detail_spec = None
-        id = 'PublicIp'
+        id = 'AllocationId'
         filter_name = 'PublicIps'
         filter_type = 'list'
         name = 'PublicIp'

--- a/tests/unit/responses/addresses/ec2.DescribeAddresses_1.json
+++ b/tests/unit/responses/addresses/ec2.DescribeAddresses_1.json
@@ -1,0 +1,46 @@
+{
+  "status_code": 200,
+  "data": {
+    "Addresses": [
+      {
+        "InstanceId": "i-05ca6c180a9426c1c",
+        "PublicIp": "18.137.255.223",
+        "AllocationId": "eipalloc-091f2b843804f008c",
+        "AssociationId": "eipassoc-0aeebf9ede25e7090",
+        "Domain": "vpc",
+        "NetworkInterfaceId": "eni-0f41b9ac56272e485",
+        "NetworkInterfaceOwnerId": "123456789012",
+        "PrivateIpAddress": "172.31.39.169",
+        "Tags": [
+        ],
+        "PublicIpv4Pool": "amazon",
+        "NetworkBorderGroup": "us-east-1"
+      },
+      {
+        "PublicIp": "18.158.53.117",
+        "AllocationId": "eipalloc-05ad23d4ddd56388a",
+        "Domain": "vpc",
+        "PublicIpv4Pool": "amazon",
+        "NetworkBorderGroup": "us-east-1"
+      },
+      {
+        "PublicIp": "52.29.40.134",
+        "AllocationId": "eipalloc-0a2c29e29c85027cc",
+        "Domain": "vpc",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "some-name"
+          },
+          {
+            "Key": "Env",
+            "Value": "Prod"
+          }
+        ],
+        "PublicIpv4Pool": "amazon",
+        "NetworkBorderGroup": "us-east-1"
+      }
+    ]
+  }
+}
+

--- a/tests/unit/responses/peeringconnections/ec2.DescribeVpcPeeringConnections_1.json
+++ b/tests/unit/responses/peeringconnections/ec2.DescribeVpcPeeringConnections_1.json
@@ -1,0 +1,48 @@
+{
+  "status_code": 200,
+  "data": {
+    "VpcPeeringConnections": [
+      {
+        "AccepterVpcInfo": {
+          "CidrBlock": "10.0.0.0/24",
+          "CidrBlockSet": [
+            {
+              "CidrBlock": "10.0.0.0/24"
+            }
+          ],
+          "OwnerId": "123456789012",
+          "PeeringOptions": {
+            "AllowDnsResolutionFromRemoteVpc": false,
+            "AllowEgressFromLocalClassicLinkToRemoteVpc": false,
+            "AllowEgressFromLocalVpcToRemoteClassicLink": false
+          },
+          "VpcId": "vpc-008f18a8d8ea05b80",
+          "Region": "eu-central-1"
+        },
+        "RequesterVpcInfo": {
+          "CidrBlock": "168.31.0.0/16",
+          "CidrBlockSet": [
+            {
+              "CidrBlock": "168.31.0.0/16"
+            }
+          ],
+          "OwnerId": "123456789012",
+          "PeeringOptions": {
+            "AllowDnsResolutionFromRemoteVpc": false,
+            "AllowEgressFromLocalClassicLinkToRemoteVpc": false,
+            "AllowEgressFromLocalVpcToRemoteClassicLink": false
+          },
+          "VpcId": "vpc-008ad710ae2d7ad28",
+          "Region": "eu-central-1"
+        },
+        "Status": {
+          "Code": "active",
+          "Message": "Active"
+        },
+        "Tags": [],
+        "VpcPeeringConnectionId": "pcx-027a582b95db2af78"
+      }
+    ]
+  }
+}
+

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -387,3 +387,18 @@ class TestARN(unittest.TestCase):
 
         self.assertEqual(l[2].data['Tags'],
                          [{'Key': 'Name', 'Value': 'some-name'}, {'Key': 'Env', 'Value': 'Prod'}])
+
+
+    def test_vpc_peering_connection(self):
+        placebo_cfg = {
+            'placebo': placebo,
+            'placebo_dir': self._get_response_path('peeringconnections'),
+            'placebo_mode': 'playback'}
+        arn = scan(
+            'arn:aws:ec2:us-east-1:123456789012:vpc-peering-connection/*',
+            **placebo_cfg)
+        l = list(arn)
+        self.assertEqual(len(l), 1)
+        self.assertEqual(l[0].arn, 'arn:aws:ec2:us-east-1:123456789012:vpc-peering-connection/pcx-027a582b95db2af78')
+
+

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -370,3 +370,20 @@ class TestARN(unittest.TestCase):
         self.assertEqual(r.data['EnvironmentName'], "Env1")
         self.assertEqual(r.arn, "arn:aws:elasticbeanstalk:us-west-2:123456789012:environment/sample-application/Env1")
         self.assertEqual(r.data['ApplicationName'], "sample-application")
+
+    def test_ec2_address(self):
+        placebo_cfg = {
+            'placebo': placebo,
+            'placebo_dir': self._get_response_path('addresses'),
+            'placebo_mode': 'playback'}
+        arn = scan(
+            'arn:aws:ec2:us-east-1:123456789012:address/*',
+            **placebo_cfg)
+        l = list(arn)
+        self.assertEqual(len(l), 3)
+        self.assertEqual(l[0].arn, 'arn:aws:ec2:us-east-1:123456789012:address/eipalloc-091f2b843804f008c')
+        self.assertEqual(l[0].data['AllocationId'],
+                         'eipalloc-091f2b843804f008c')
+
+        self.assertEqual(l[2].data['Tags'],
+                         [{'Key': 'Name', 'Value': 'some-name'}, {'Key': 'Env', 'Value': 'Prod'}])


### PR DESCRIPTION
Hi,

this PR updates the ARN pattern of an EC 2 address  from 
`arn:aws:ec2:eu-central-1:123456789012:elastic-ip/18.137.255.223`
to 
`arn:aws:ec2:eu-central-1:123456789012:elastic-ip/eipalloc-05ab22d4ddd56388a`
The current ARN pattern uses the AllocationId instead of the public IP.

Futhermore a small adaption to the enum spec of peering connection was required because the list returned is now called `VpcPeeringConnections`