### PR TITLE
Update resource regions

### DIFF
--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -183,7 +183,6 @@ class Region(ARNComponent):
         'route53': _no_region_required,
         'lambda': ['ap-northeast-1', 'ap-northeast-2', 'ap-south-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1',
                    'eu-west-1', 'eu-west-2', 'sa-east-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'],
-        'firehose': ['us-east-1', 'us-west-2', 'eu-west-1'],
         'apigateway': ['us-east-1', 'us-west-2', 'eu-west-1', 'ap-northeast-1'],
     }
 

--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -183,7 +183,6 @@ class Region(ARNComponent):
         'route53': _no_region_required,
         'lambda': ['ap-northeast-1', 'ap-northeast-2', 'ap-south-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1',
                    'eu-west-1', 'eu-west-2', 'sa-east-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'],
-        'apigateway': ['us-east-1', 'us-west-2', 'eu-west-1', 'ap-northeast-1'],
     }
 
     def choices(self, context=None):

--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -172,20 +172,12 @@ class Region(ARNComponent):
                          'cn-north-1',
                          'cn-northwest-1']
 
-    _region_names_limited = ['us-east-1',
-                             'us-west-2',
-                             'eu-west-1',
-                             'ap-southeast-1',
-                             'ap-southeast-2',
-                             'ap-northeast-1']
-
     _no_region_required = ['']
 
     _service_region_map = {
         'redshift': _all_region_names,
         'glacier': ['ap-northeast-1', 'ap-northeast-2', 'ap-south-1', 'ap-southeast-2', 'ca-central-1', 'eu-central-1',
                     'eu-west-1', 'eu-west-2', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'],
-        'kinesis': _region_names_limited,
         'cloudfront': _no_region_required,
         'iam': _no_region_required,
         'route53': _no_region_required

--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -180,9 +180,7 @@ class Region(ARNComponent):
         'kinesis': _region_names_limited,
         'cloudfront': _no_region_required,
         'iam': _no_region_required,
-        'route53': _no_region_required,
-        'lambda': ['ap-northeast-1', 'ap-northeast-2', 'ap-south-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1',
-                   'eu-west-1', 'eu-west-2', 'sa-east-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'],
+        'route53': _no_region_required
     }
 
     def choices(self, context=None):

--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -155,14 +155,22 @@ class Region(ARNComponent):
                          'us-west-2',
                          'eu-west-1',
                          'eu-west-2',
+                         'eu-west-3',
                          'eu-central-1',
+                         'eu-north-1',
+                         'eu-south-1',
                          'ap-southeast-1',
                          'ap-southeast-2',
                          'ap-northeast-1',
                          'ap-northeast-2',
                          'ap-south-1',
+                         'ap-east-1',
+                         'af-south-1'
                          'ca-central-1',
-                         'sa-east-1']
+                         'sa-east-1',
+                         'me-south-1',
+                         'cn-north-1',
+                         'cn-northwest-1']
 
     _region_names_limited = ['us-east-1',
                              'us-west-2',


### PR DESCRIPTION
Hi,
I updated the region dict. New regions have been added.
Firehose, Apigateway, Lambda and kinesis data streams are available in every region currently listed in `_all_region_names`. Therefore I removed them from the service map.