### PR TITLE
Fix sqs arn

### DIFF
--- a/skew/resources/aws/sqs.py
+++ b/skew/resources/aws/sqs.py
@@ -35,3 +35,11 @@ class Queue(AWSResource):
         self.data = {self.Meta.id: data,
                      'QueueName': data.split('/')[-1]}
         self._id = self.data['QueueName']
+
+    @property
+    def arn(self):
+        return 'arn:aws:%s:%s:%s:%s' % (
+            self._client.service_name,
+            self._client.region_name,
+            self._client.account_id,
+            self.id)

--- a/tests/unit/responses/queues/sqs.ListQueueTags_1.json
+++ b/tests/unit/responses/queues/sqs.ListQueueTags_1.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 200,
+  "data": {
+    "Tags": {
+      "Env": "Production",
+      "Project": "Marketing"
+    }
+  }
+}

--- a/tests/unit/responses/queues/sqs.ListQueues_1.json
+++ b/tests/unit/responses/queues/sqs.ListQueues_1.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 200,
+  "data": {
+    "QueueUrls": [
+      "https://us-east-1.queue.amazonaws.com/123456789012/someq"
+    ]
+  }
+
+}

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -388,7 +388,6 @@ class TestARN(unittest.TestCase):
         self.assertEqual(l[2].data['Tags'],
                          [{'Key': 'Name', 'Value': 'some-name'}, {'Key': 'Env', 'Value': 'Prod'}])
 
-
     def test_vpc_peering_connection(self):
         placebo_cfg = {
             'placebo': placebo,
@@ -401,4 +400,17 @@ class TestARN(unittest.TestCase):
         self.assertEqual(len(l), 1)
         self.assertEqual(l[0].arn, 'arn:aws:ec2:us-east-1:123456789012:vpc-peering-connection/pcx-027a582b95db2af78')
 
+    def test_sqs_queue(self):
+        placebo_cfg = {
+            'placebo': placebo,
+            'placebo_dir': self._get_response_path('queues'),
+            'placebo_mode': 'playback'}
 
+        arn = scan(
+            'arn:aws:sqs:us-east-1:123456789012:queue/*',
+            **placebo_cfg)
+        l = list(arn)
+        self.assertEqual(len(l), 1)
+        self.assertEqual(l[0].arn, 'arn:aws:sqs:us-east-1:123456789012:someq')
+        self.assertEqual(l[0].tags['Env'], 'Production')
+        self.assertEqual(l[0].tags['Project'], 'Marketing')


### PR DESCRIPTION
Fixed the SQS topic ARN pattern

Old:
`arn:aws:sqs:us-east-1:123456789012:queue:<QUEUENAME>`
New:
`arn:aws:sqs:us-east-1:123456789012:<QUEUENAME>`

Also I verified that tags are retrieved ( #132 can be closed IMO)