### PR TITLE
Add test for iam role

### DIFF
--- a/tests/unit/responses/roles/iam.ListRoleTags_1.json
+++ b/tests/unit/responses/roles/iam.ListRoleTags_1.json
@@ -1,0 +1,16 @@
+{
+  "status_code": 200,
+  "data": {
+    "Tags": [
+      {
+        "Key": "Project",
+        "Value": "Marketing"
+      },
+      {
+        "Key": "Env",
+        "Value": "Production"
+      }
+    ],
+    "IsTruncated": false
+  }
+}

--- a/tests/unit/responses/roles/iam.ListRoles_1.json
+++ b/tests/unit/responses/roles/iam.ListRoles_1.json
@@ -1,0 +1,47 @@
+{
+  "status_code": 200,
+  "data": {
+    "Roles": [
+      {
+        "Path": "/",
+        "RoleName": "aws-elasticbeanstalk-ec2-role",
+        "RoleId": "AROA4TJGIIIZTEMWZ7AX5",
+        "Arn": "arn:aws:iam::123456789012:role/aws-elasticbeanstalk-ec2-role",
+        "CreateDate": "2020-07-09T06:02:54Z",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::123456789012:root"
+              },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        },
+        "MaxSessionDuration": 3600
+      },
+      {
+        "Path": "/",
+        "RoleName": "aws-lambda-role",
+        "RoleId": "AROA4TJGIIIZTEMWZ7AX4",
+        "Arn": "arn:aws:iam::123456789012:role/aws-lambda-role",
+        "CreateDate": "2020-07-09T08:05:54Z",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::123456789012:root"
+              },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        },
+        "MaxSessionDuration": 3600
+      }
+    ]
+  }
+}

--- a/tests/unit/test_arn.py
+++ b/tests/unit/test_arn.py
@@ -212,6 +212,16 @@ class TestARN(unittest.TestCase):
                          'arn:aws:iam::aws:policy/AdministratorAccess')
         self.assertEqual(l[0].data['SSHPublicKeys'][0]['SSHPublicKeyId'],
                          'APKAAAAAAAAAAAAAAAAA')
+    def test_iam_roles(self):
+        placebo_cfg = {
+            'placebo': placebo,
+            'placebo_dir': self._get_response_path('roles'),
+            'placebo_mode': 'playback'}
+        arn = scan('arn:aws:iam::123456789012:role/*',
+                   **placebo_cfg)
+        l = list(arn)
+        self.assertEqual(len(l), 2)
+        self.assertEqual(l[0].arn, 'arn:aws:iam::123456789012:role/aws-elasticbeanstalk-ec2-role')
 
     def test_cloudformation_stacks(self):
         placebo_cfg = {


### PR DESCRIPTION
I tried to add a test for IAM roles. 
Unfortunately when adding a complete response for `list_roles` operation I stumbled across an error.
If `"AssumeRolePolicyDocument"` is included in the response botocore calls `json_decode_policies` which results in the following error:

```
Traceback (most recent call last):
  File "/home/tobias/work/repos/skew/tests/unit/test_arn.py", line 222, in test_iam_roles
    l = list(arn)
  File "/home/tobias/work/repos/skew/skew/arn/__init__.py", line 323, in __iter__
    for scheme in self.scheme.enumerate(context, **self.kwargs):
  File "/home/tobias/work/repos/skew/skew/arn/__init__.py", line 247, in enumerate
    for provider in self._arn.provider.enumerate(
  File "/home/tobias/work/repos/skew/skew/arn/__init__.py", line 232, in enumerate
    for service in self._arn.service.enumerate(
  File "/home/tobias/work/repos/skew/skew/arn/__init__.py", line 217, in enumerate
    for region in self._arn.region.enumerate(
  File "/home/tobias/work/repos/skew/skew/arn/__init__.py", line 198, in enumerate
    for account in self._arn.account.enumerate(
  File "/home/tobias/work/repos/skew/skew/arn/__init__.py", line 145, in enumerate
    for resource in self._arn.resource.enumerate(
  File "/home/tobias/work/repos/skew/skew/arn/__init__.py", line 127, in enumerate
    resources.extend(resource_cls.enumerate(
  File "/home/tobias/work/repos/skew/skew/resources/resource.py", line 54, in enumerate
    data = client.call(enum_op, query=path, **kwargs)
  File "/home/tobias/work/repos/skew/skew/awsclient.py", line 120, in call
    data = results.build_full_result()
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/paginate.py", line 449, in build_full_result
    for response in self:
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/paginate.py", line 255, in __iter__
    response = self._make_request(current_kwargs)
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/paginate.py", line 332, in _make_request
    return self._method(**current_kwargs)
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/client.py", line 624, in _make_api_call
    self.meta.events.emit(
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/hooks.py", line 356, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/hooks.py", line 228, in emit
    return self._emit(event_name, kwargs)
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/hooks.py", line 211, in _emit
    response = handler(**kwargs)
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/handlers.py", line 446, in json_decode_policies
    _decode_policy_types(parsed, model.output_shape)
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/handlers.py", line 461, in _decode_policy_types
    _decode_policy_types(parsed[member_name], member_shape)
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/handlers.py", line 465, in _decode_policy_types
    _decode_policy_types(item, shape_member)
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/handlers.py", line 458, in _decode_policy_types
    parsed[member_name] = decode_quoted_jsondoc(
  File "/home/tobias/.local/share/virtualenvs/skew-4OWl7ITO/lib/python3.8/site-packages/botocore/handlers.py", line 180, in decode_quoted_jsondoc
    value = json.loads(unquote(value))
  File "/usr/lib/python3.8/urllib/parse.py", line 635, in unquote
    string.split
AttributeError: 'dict' object has no attribute 'split'
```

It looks to me like the `AssumeRolePolicyDocument` should be a string and not a dict. 
However when making a boto call to `list_roles`  `AssumeRolePolicyDocument` is a python dict, so I think my json response is valid?
Can I safely ignore this issue and change  `AssumeRolePolicyDocument` to an escaped string containing the dict ?