### PR TITLE
Fix #172: separate regions properly

### DIFF
--- a/skew/arn/__init__.py
+++ b/skew/arn/__init__.py
@@ -165,7 +165,7 @@ class Region(ARNComponent):
                          'ap-northeast-2',
                          'ap-south-1',
                          'ap-east-1',
-                         'af-south-1'
+                         'af-south-1',
                          'ca-central-1',
                          'sa-east-1',
                          'me-south-1',

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -62,3 +62,7 @@ class TestResource(unittest.TestCase):
     def test_all_services(self):
         all_providers = skew.resources.all_services('aws')
         self.assertEqual(len(all_providers), 24)
+
+    def test_all_regions(self):
+        all_regions = skew.arn.Region('arn:aws:*:*:*:*', 'arn:aws:*:*:*:*').__getattribute__('_all_region_names')
+        self.assertEqual(len(all_regions), 22)


### PR DESCRIPTION
Hi,
added the missing comma to separate regions properly.
Furthermore I added a test checking the number of regions to prevent this error from happening again.
